### PR TITLE
misc: add preliminary support for pinone devices, fix wemos d1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,190 +73,182 @@ set(CMAKE_C_VISIBILITY_PRESET hidden)
 set(LIBDOF_SOURCES
    src/Config.cpp
    src/DOF.cpp
-   src/Pinball.cpp
+   src/DirectOutputHandler.cpp
    src/Log.cpp
    src/Logger.cpp
-   src/DirectOutputHandler.cpp
-   
+   src/Pinball.cpp
+
+   src/general/Curve.cpp
    src/general/DirectoryInfo.cpp
    src/general/FileInfo.cpp
-   src/general/FileReader.cpp
    src/general/FilePattern.cpp
    src/general/FilePatternList.cpp
-   src/general/StringExtensions.cpp
+   src/general/FileReader.cpp
    src/general/MathExtensions.cpp
-   src/general/Curve.cpp
-   src/general/generic/NameChangeEventArgs.cpp
-   src/general/generic/NamedItemBase.cpp
-   src/general/color/RGBAColor.cpp
-   src/general/color/RGBColor.cpp
-   src/general/color/RGBAColorNamed.cpp
-   src/general/color/RGBColorNamed.cpp
+   src/general/StringExtensions.cpp
+   src/general/analog/AnalogAlpha.cpp
+   src/general/bitmap/FastBitmap.cpp
    src/general/color/ColorList.cpp
    src/general/color/ColorScale.cpp
-   src/general/analog/AnalogAlpha.cpp
-   
-   src/general/bitmap/FastBitmap.cpp
-   
-   src/fx/matrixfx/bitmapshapes/Shape.cpp
-   src/fx/matrixfx/bitmapshapes/ShapeList.cpp
-   src/fx/matrixfx/bitmapshapes/ShapeAnimated.cpp
-   src/fx/matrixfx/bitmapshapes/ShapeDefinitions.cpp
-   
+   src/general/color/RGBAColor.cpp
+   src/general/color/RGBAColorNamed.cpp
+   src/general/color/RGBColor.cpp
+   src/general/color/RGBColorNamed.cpp
+   src/general/generic/NameChangeEventArgs.cpp
+   src/general/generic/NamedItemBase.cpp
+
    src/globalconfiguration/GlobalConfig.cpp
 
    src/pinballsupport/AlarmHandler.cpp
    src/pinballsupport/InputQueue.cpp
 
-   src/fx/AssignedEffect.cpp
-   src/fx/AssignedEffectList.cpp
-   src/fx/EffectList.cpp
-   src/fx/IEffect.cpp
-   src/fx/EffectBase.cpp
-   src/fx/EffectEffectBase.cpp
-   src/fx/EffectEventArgs.cpp
-   src/fx/EffectFactory.cpp
-   src/fx/EffectRegistrations.cpp
-   src/fx/analogtoyfx/AnanlogToyEffectBase.cpp
-   src/fx/analogtoyfx/AnalogToyValueEffect.cpp
-   src/fx/conditionfx/TableElementConditionEffect.cpp
-   src/fx/listfx/ListEffect.cpp
-   src/fx/matrixfx/RGBAMatrixColorEffect.cpp
-   src/fx/matrixfx/AnalogAlphaMatrixValueEffect.cpp
-   src/fx/matrixfx/RGBAMatrixFlickerEffect.cpp
-   src/fx/matrixfx/RGBAMatrixShiftEffect.cpp
-   src/fx/matrixfx/RGBAMatrixPlasmaEffect.cpp
-   src/fx/matrixfx/AnalogAlphaMatrixFlickerEffect.cpp
-   src/fx/matrixfx/AnalogAlphaMatrixShiftEffect.cpp
-   src/fx/matrixfx/RGBAMatrixBitmapEffect.cpp
-   src/fx/matrixfx/RGBAMatrixBitmapAnimationEffect.cpp
-   src/fx/matrixfx/AnalogAlphaMatrixBitmapEffect.cpp
-   src/fx/matrixfx/AnalogAlphaMatrixBitmapAnimationEffect.cpp
-   src/fx/matrixfx/RGBAMatrixColorScaleBitmapEffect.cpp
-   src/fx/matrixfx/RGBAMatrixColorScaleBitmapAnimationEffect.cpp
-   src/fx/matrixfx/MatrixEffectBase.cpp
-   src/fx/matrixfx/MatrixValueEffectBase.cpp
-   src/fx/matrixfx/MatrixBitmapEffectBase.cpp
-   src/fx/matrixfx/MatrixBitmapAnimationEffectBase.cpp
-   src/fx/matrixfx/MatrixColorScaleEffectBase.cpp
-   src/fx/matrixfx/MatrixFlickerEffectBase.cpp
-   src/fx/matrixfx/MatrixPlasmaEffectBase.cpp
-   src/fx/matrixfx/MatrixShiftEffectBase.cpp
-   src/fx/matrixfx/RGBAMatrixShapeEffect.cpp
-   src/fx/matrixfx/RGBAMatrixColorScaleShapeEffect.cpp
-   src/fx/nullfx/NullEffect.cpp
-   src/fx/rgbafx/RGBAEffectBase.cpp
-   src/fx/rgbafx/RGBAColorEffect.cpp
-   src/fx/valuefx/ValueInvertEffect.cpp
-   src/fx/valuefx/ValueMapFullRangeEffect.cpp
-   src/fx/timmedfx/DelayEffect.cpp
-   src/fx/timmedfx/DurationEffect.cpp
-   src/fx/timmedfx/BlinkEffect.cpp
-   src/fx/timmedfx/MinDurationEffect.cpp
-   src/fx/timmedfx/MaxDurationEffect.cpp
-   src/fx/timmedfx/ExtendDurationEffect.cpp
-   src/fx/timmedfx/FadeEffect.cpp
-   
    src/table/Table.cpp
    src/table/TableElement.cpp
    src/table/TableElementData.cpp
    src/table/TableElementList.cpp
 
-   src/cab/ICabinetOwner.cpp
-   src/cab/CabinetOwner.cpp
+   src/fx/AssignedEffect.cpp
+   src/fx/AssignedEffectList.cpp
+   src/fx/EffectBase.cpp
+   src/fx/EffectEffectBase.cpp
+   src/fx/EffectEventArgs.cpp
+   src/fx/EffectFactory.cpp
+   src/fx/EffectList.cpp
+   src/fx/EffectRegistrations.cpp
+   src/fx/IEffect.cpp
+   src/fx/analogtoyfx/AnanlogToyEffectBase.cpp
+   src/fx/analogtoyfx/AnalogToyValueEffect.cpp
+   src/fx/conditionfx/TableElementConditionEffect.cpp
+   src/fx/listfx/ListEffect.cpp
+   src/fx/matrixfx/AnalogAlphaMatrixBitmapAnimationEffect.cpp
+   src/fx/matrixfx/AnalogAlphaMatrixBitmapEffect.cpp
+   src/fx/matrixfx/AnalogAlphaMatrixFlickerEffect.cpp
+   src/fx/matrixfx/AnalogAlphaMatrixShiftEffect.cpp
+   src/fx/matrixfx/AnalogAlphaMatrixValueEffect.cpp
+   src/fx/matrixfx/MatrixBitmapAnimationEffectBase.cpp
+   src/fx/matrixfx/MatrixBitmapEffectBase.cpp
+   src/fx/matrixfx/MatrixColorScaleEffectBase.cpp
+   src/fx/matrixfx/MatrixEffectBase.cpp
+   src/fx/matrixfx/MatrixFlickerEffectBase.cpp
+   src/fx/matrixfx/MatrixPlasmaEffectBase.cpp
+   src/fx/matrixfx/MatrixShiftEffectBase.cpp
+   src/fx/matrixfx/MatrixValueEffectBase.cpp
+   src/fx/matrixfx/RGBAMatrixBitmapAnimationEffect.cpp
+   src/fx/matrixfx/RGBAMatrixBitmapEffect.cpp
+   src/fx/matrixfx/RGBAMatrixColorEffect.cpp
+   src/fx/matrixfx/RGBAMatrixColorScaleBitmapAnimationEffect.cpp
+   src/fx/matrixfx/RGBAMatrixColorScaleBitmapEffect.cpp
+   src/fx/matrixfx/RGBAMatrixColorScaleShapeEffect.cpp
+   src/fx/matrixfx/RGBAMatrixFlickerEffect.cpp
+   src/fx/matrixfx/RGBAMatrixPlasmaEffect.cpp
+   src/fx/matrixfx/RGBAMatrixShapeEffect.cpp
+   src/fx/matrixfx/RGBAMatrixShiftEffect.cpp
+   src/fx/matrixfx/bitmapshapes/Shape.cpp
+   src/fx/matrixfx/bitmapshapes/ShapeAnimated.cpp
+   src/fx/matrixfx/bitmapshapes/ShapeDefinitions.cpp
+   src/fx/matrixfx/bitmapshapes/ShapeList.cpp
+   src/fx/nullfx/NullEffect.cpp
+   src/fx/rgbafx/RGBAColorEffect.cpp
+   src/fx/rgbafx/RGBAEffectBase.cpp
+   src/fx/timmedfx/BlinkEffect.cpp
+   src/fx/timmedfx/DelayEffect.cpp
+   src/fx/timmedfx/DurationEffect.cpp
+   src/fx/timmedfx/ExtendDurationEffect.cpp
+   src/fx/timmedfx/FadeEffect.cpp
+   src/fx/timmedfx/MaxDurationEffect.cpp
+   src/fx/timmedfx/MinDurationEffect.cpp
+   src/fx/valuefx/ValueInvertEffect.cpp
+   src/fx/valuefx/ValueMapFullRangeEffect.cpp
+
    src/cab/Cabinet.cpp
    src/cab/CabinetOutputList.cpp
-
+   src/cab/CabinetOwner.cpp
+   src/cab/ICabinetOwner.cpp
+   src/cab/out/IAutoConfigOutputController.cpp
    src/cab/out/IOutput.cpp
-   src/cab/out/Output.cpp
-   src/cab/out/OutputList.cpp
-   src/cab/out/Out.cpp
    src/cab/out/IOutputController.cpp
+   src/cab/out/ISupportsSetValues.cpp
+   src/cab/out/NullOutputController.cpp
+   src/cab/out/Out.cpp
+   src/cab/out/Output.cpp
    src/cab/out/OutputControllerBase.cpp
    src/cab/out/OutputControllerCompleteBase.cpp
    src/cab/out/OutputControllerFlexCompleteBase.cpp
    src/cab/out/OutputControllerList.cpp
-   src/cab/out/IAutoConfigOutputController.cpp
-   src/cab/out/ISupportsSetValues.cpp
-   src/cab/out/NullOutputController.cpp
-
+   src/cab/out/OutputList.cpp
+   src/cab/out/dmx/ArtNet.cpp
+   src/cab/out/dmx/DMX.cpp
+   src/cab/out/dmx/DMXOutput.cpp
+   src/cab/out/dmx/artnetengine/ArtnetEngine.cpp
+   src/cab/out/dmx/artnetengine/Engine.cpp
+   src/cab/overrides/TableOverrideSetting.cpp
+   src/cab/overrides/TableOverrideSettingDevice.cpp
+   src/cab/overrides/TableOverrideSettings.cpp
+   src/cab/schedules/ScheduledSetting.cpp
+   src/cab/schedules/ScheduledSettingDevice.cpp
+   src/cab/schedules/ScheduledSettings.cpp
+   src/cab/sequencer/SequentialOutputSetting.cpp
+   src/cab/sequencer/SequentialOutputSettings.cpp
    src/cab/toys/IToy.cpp
    src/cab/toys/IToyUpdatable.cpp
    src/cab/toys/ToyBase.cpp
    src/cab/toys/ToyBaseUpdatable.cpp
-   src/cab/toys/ToyList.cpp
    src/cab/toys/ToyEventArgs.cpp
-   src/cab/toys/layer/RGBAToy.cpp
-   src/cab/toys/layer/AnalogAlphaToy.cpp
-   src/cab/toys/layer/AlphaMappingTable.cpp
-   src/cab/toys/lwequivalent/LedWizEquivalent.cpp
-   src/cab/toys/hardware/Motor.cpp
+   src/cab/toys/ToyList.cpp
    src/cab/toys/hardware/GearMotor.cpp
-   src/cab/toys/hardware/Shaker.cpp
-   src/cab/toys/hardware/RGBLed.cpp
    src/cab/toys/hardware/Lamp.cpp
    src/cab/toys/hardware/LedStrip.cpp
+   src/cab/toys/hardware/Motor.cpp
+   src/cab/toys/hardware/RGBLed.cpp
+   src/cab/toys/hardware/Shaker.cpp
+   src/cab/toys/layer/AlphaMappingTable.cpp
+   src/cab/toys/layer/AnalogAlphaToy.cpp
+   src/cab/toys/layer/RGBAToy.cpp
+   src/cab/toys/lwequivalent/LedWizEquivalent.cpp
    src/cab/toys/virtual/AnalogAlphaToyGroup.cpp
    src/cab/toys/virtual/RGBAToyGroup.cpp
 
-   src/cab/overrides/TableOverrideSettings.cpp
-   src/cab/overrides/TableOverrideSetting.cpp
-
-   src/cab/schedules/ScheduledSetting.cpp
-   src/cab/schedules/ScheduledSettings.cpp
-   src/cab/sequencer/SequentialOutputSetting.cpp
-   src/cab/sequencer/SequentialOutputSettings.cpp
-   src/cab/overrides/TableOverrideSettingDevice.cpp
-
+   src/ledcontrol/loader/ColorConfig.cpp
+   src/ledcontrol/loader/ColorConfigList.cpp
    src/ledcontrol/loader/LedControl.cpp
    src/ledcontrol/loader/LedControlConfig.cpp
    src/ledcontrol/loader/LedControlConfigList.cpp
    src/ledcontrol/loader/TableConfig.cpp
-   src/ledcontrol/loader/TableConfigList.cpp
    src/ledcontrol/loader/TableConfigColumn.cpp
    src/ledcontrol/loader/TableConfigColumnList.cpp
+   src/ledcontrol/loader/TableConfigList.cpp
    src/ledcontrol/loader/TableConfigSetting.cpp
-   src/ledcontrol/loader/VariablesDictionary.cpp
    src/ledcontrol/loader/TableVariablesDictionary.cpp
-   src/ledcontrol/loader/ColorConfig.cpp
-   src/ledcontrol/loader/ColorConfigList.cpp
+   src/ledcontrol/loader/VariablesDictionary.cpp
    src/ledcontrol/setup/Configurator.cpp
-
-   src/cab/out/dmx/DMX.cpp
-   src/cab/out/dmx/DMXOutput.cpp
-   src/cab/out/dmx/ArtNet.cpp
-   src/cab/out/dmx/artnetengine/ArtnetEngine.cpp
-   src/cab/out/dmx/artnetengine/Engine.cpp
 
    third-party/include/tinyxml2/tinyxml2.cpp
 )
 
 if(PLATFORM STREQUAL "win" OR PLATFORM STREQUAL "macos" OR PLATFORM STREQUAL "linux")
    list(APPEND LIBDOF_SOURCES
-      src/cab/out/ps/Pinscape.cpp
-      src/cab/out/ps/PinscapeAutoConfigurator.cpp
-
-      src/cab/out/pspico/PinscapePico.cpp
-      src/cab/out/pspico/PinscapePicoAutoConfigurator.cpp
-
-      src/cab/out/lw/LedWiz.cpp
-      src/cab/out/lw/LedWizAutoConfigurator.cpp
-
-      src/cab/out/dudescab/DudesCab.cpp
-      src/cab/out/dudescab/DudesCabAutoConfigurator.cpp
-
-      src/cab/out/adressableledstrip/TeensyStripController.cpp
-      src/cab/out/adressableledstrip/LedStripOutput.cpp
       src/cab/out/adressableledstrip/DirectStripController.cpp
       src/cab/out/adressableledstrip/DirectStripControllerApi.cpp
-      src/cab/out/adressableledstrip/WS2811StripController.cpp
+      src/cab/out/adressableledstrip/LedStripOutput.cpp
+      src/cab/out/adressableledstrip/TeensyStripController.cpp
       src/cab/out/adressableledstrip/WemosD1StripController.cpp
-
-      src/cab/out/ftdichip/FTDI.cpp
+      src/cab/out/adressableledstrip/WS2811StripController.cpp
+      src/cab/out/comport/PinControl.cpp
+      src/cab/out/dudescab/DudesCab.cpp
+      src/cab/out/dudescab/DudesCabAutoConfigurator.cpp
       src/cab/out/ftdichip/FT245RBitbangController.cpp
       src/cab/out/ftdichip/FT245RBitbangControllerAutoConfigurator.cpp
-
-      src/cab/out/comport/PinControl.cpp
+      src/cab/out/ftdichip/FTDI.cpp
+      src/cab/out/lw/LedWiz.cpp
+      src/cab/out/lw/LedWizAutoConfigurator.cpp
+      src/cab/out/pinone/NamedPipeServer.cpp
+      src/cab/out/pinone/PinOne.cpp
+      src/cab/out/pinone/PinOneAutoConfigurator.cpp
+      src/cab/out/pinone/PinOneCommunication.cpp
+      src/cab/out/ps/Pinscape.cpp
+      src/cab/out/ps/PinscapeAutoConfigurator.cpp
+      src/cab/out/pspico/PinscapePico.cpp
+      src/cab/out/pspico/PinscapePicoAutoConfigurator.cpp
    )
 endif()
 

--- a/README.md
+++ b/README.md
@@ -20,13 +20,15 @@ This library is currently used by [Visual Pinball Standalone](https://github.com
 ### **Tested & Working**
 - **[Pinscape](http://mjrnet.org/pinscape)** - @mjrgh's popular pinball controller with 32+ outputs
 - **[Pinscape Pico](https://github.com/mjrgh/PinscapePico)** - RP2040-based version with enhanced features  
-- **[Teensy Strip Controller](https://github.com/DirectOutput/TeensyStripController)** - Teensy-based WS2812 LED strip controller
+- **[TeensyStripController](https://github.com/DirectOutput/TeensyStripController)** - Teensy based WS2812 LED strip controller
+- **[WemosD1MPStripController](https://github.com/aetios50/PincabLedStrip)** - Wemos D1 Mini Pro based WS2812 LED strip controller
 
 ### **Implemented & Ready To Test**
 - **LedWiz** - Classic 32-output controller
 - **DudesCab** - RP2040-based controller with 128 PWM outputs
 - **ArtNet/DMX** - Professional lighting control via Ethernet (all platforms)
 - **PinControl** - Arduino-based controller with 10 outputs
+- **PinOne** - Cleveland Software Design controller with 63 outputs
 - **FTDI Controllers** - FT245R bitbang controllers  
 - **WS2811/WS2812 LED Strips** - Addressable LED strip support
 
@@ -34,7 +36,6 @@ This library is currently used by [Visual Pinball Standalone](https://github.com
 - **PAC Controllers** (PacDrive, PacLed64, PacUIO) - *Windows DLL dependencies*
 - **SSF Controllers** - *Audio-based feedback systems*  
 - **Philips Hue** - *Smart lighting integration*
-- **PinOne**
 
 `libdof` is actively used by [Visual Pinball Standalone](https://github.com/vpinball/vpinball/tree/standalone) and continues expanding controller support. 
 
@@ -151,4 +152,153 @@ cmake --build build
 platforms/android/arm64-v8a/external.sh
 cmake -DPLATFORM=android -DARCH=arm64-v8a -DCMAKE_BUILD_TYPE=Release -B build
 cmake --build build
+```
+
+## Configuration:
+
+For custom setups, create a `CabinetConfig.xml` file in your DOF config directory:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<Cabinet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Name>Test Cabinet with Multiple Controllers</Name>
+  <OutputControllers>
+    <!-- Teensy LED Strip Controller -->
+    <TeensyStripController>
+      <Name>Cabinet Teensy</Name>
+      <ComPortName>/dev/cu.usbmodem104409301</ComPortName>
+      <ComPortBaudRate>9600</ComPortBaudRate>
+      <ComPortParity>None</ComPortParity>
+      <ComPortDataBits>8</ComPortDataBits>
+      <ComPortStopBits>One</ComPortStopBits>
+      <ComPortTimeOutMs>200</ComPortTimeOutMs>
+      <ComPortOpenWaitMs>50</ComPortOpenWaitMs>
+      <ComPortHandshakeStartWaitMs>20</ComPortHandshakeStartWaitMs>
+      <ComPortHandshakeEndWaitMs>50</ComPortHandshakeEndWaitMs>
+      <ComPortDtrEnable>false</ComPortDtrEnable>
+      <NumberOfLedsStrip1>36</NumberOfLedsStrip1>
+      <NumberOfLedsStrip2>36</NumberOfLedsStrip2>
+      <NumberOfLedsStrip3>0</NumberOfLedsStrip3>
+      <NumberOfLedsStrip4>0</NumberOfLedsStrip4>
+      <NumberOfLedsStrip5>0</NumberOfLedsStrip5>
+      <NumberOfLedsStrip6>0</NumberOfLedsStrip6>
+      <NumberOfLedsStrip7>0</NumberOfLedsStrip7>
+      <NumberOfLedsStrip8>0</NumberOfLedsStrip8>
+      <NumberOfLedsStrip9>0</NumberOfLedsStrip9>
+      <NumberOfLedsStrip10>0</NumberOfLedsStrip10>
+    </TeensyStripController>
+
+    <!-- Wemos LED Strip Controller -->
+    <WemosD1MPStripController>
+      <Name>Main Wemos</Name>
+      <ComPortName>/dev/cu.usbserial-02G5PBVF</ComPortName>
+      <ComPortBaudRate>2000000</ComPortBaudRate>
+      <ComPortParity>None</ComPortParity>
+      <ComPortDataBits>8</ComPortDataBits>
+      <ComPortStopBits>One</ComPortStopBits>
+      <ComPortTimeOutMs>500</ComPortTimeOutMs>
+      <ComPortOpenWaitMs>50</ComPortOpenWaitMs>
+      <ComPortHandshakeStartWaitMs>20</ComPortHandshakeStartWaitMs>
+      <ComPortHandshakeEndWaitMs>50</ComPortHandshakeEndWaitMs>
+      <ComPortDtrEnable>true</ComPortDtrEnable>
+      <SendPerLedstripLength>true</SendPerLedstripLength>
+      <UseCompression>false</UseCompression>
+      <TestOnConnect>false</TestOnConnect>
+      <NumberOfLedsStrip1>20</NumberOfLedsStrip1>
+      <NumberOfLedsStrip2>0</NumberOfLedsStrip2>
+      <NumberOfLedsStrip3>0</NumberOfLedsStrip3>
+      <NumberOfLedsStrip4>0</NumberOfLedsStrip4>
+      <NumberOfLedsStrip5>0</NumberOfLedsStrip5>
+      <NumberOfLedsStrip6>0</NumberOfLedsStrip6>
+      <NumberOfLedsStrip7>0</NumberOfLedsStrip7>
+      <NumberOfLedsStrip8>0</NumberOfLedsStrip8>
+      <NumberOfLedsStrip9>0</NumberOfLedsStrip9>
+      <NumberOfLedsStrip10>0</NumberOfLedsStrip10>
+    </WemosD1MPStripController>
+    
+    <!-- Pinscape Controller -->
+    <Pinscape>
+      <Name>Main Pinscape</Name>
+      <Number>1</Number>
+    </Pinscape>
+    
+    <!-- Pinscape Pico Controller -->
+    <PinscapePico>
+      <Name>Backbox Pico</Name>
+      <Number>1</Number>
+    </PinscapePico>
+  </OutputControllers>
+  
+  <Toys>    
+    <!-- LED Strip Toys for Teensy Controller -->
+    <LedStrip>
+      <Name>PF Left</Name>
+      <Width>36</Width>
+      <Height>1</Height>
+      <Brightness>100</Brightness>
+      <LedStripArrangement>TopDownLeftRight</LedStripArrangement>
+      <ColorOrder>GRB</ColorOrder>
+      <FirstLedNumber>36</FirstLedNumber> 
+      <FadingCurveName>SwissLizardsLedCurve</FadingCurveName>
+      <OutputControllerName>Cabinet Teensy</OutputControllerName>
+    </LedStrip>
+
+    <!-- LED Strip Toys for Wemos Controller -->
+    <LedStrip>
+      <Name>PF Right</Name> 
+      <Width>20</Width> 
+      <Brightness>100</Brightness>
+      <Height>1</Height>
+      <LedStripArrangement>TopDownLeftRight</LedStripArrangement>
+      <ColorOrder>RGB</ColorOrder> 
+      <FirstLedNumber>0</FirstLedNumber> 
+      <FadingCurveName>SwissLizardsLedCurve</FadingCurveName>
+      <OutputControllerName>Main Wemos</OutputControllerName>
+    </LedStrip>
+    
+    <!-- LedWizEquivalent for LED Strips (LedWiz #30) -->
+    <LedWizEquivalent>
+      <Name>LED Strip Equivalent</Name> 
+      <LedWizNumber>30</LedWizNumber>
+      <Outputs>
+        <LedWizEquivalentOutput>
+          <OutputName>PF Left</OutputName>
+          <LedWizEquivalentOutputNumber>4</LedWizEquivalentOutputNumber> 
+        </LedWizEquivalentOutput>
+        <LedWizEquivalentOutput>
+          <OutputName>PF Right</OutputName> 
+          <LedWizEquivalentOutputNumber>1</LedWizEquivalentOutputNumber>
+        </LedWizEquivalentOutput> 
+      </Outputs>
+    </LedWizEquivalent> 
+    
+    <!-- LedWizEquivalent for Pinscape (Unit 1 = LedWiz #51) -->
+    <LedWizEquivalent>
+      <Name>Main Pinscape Equivalent</Name>
+      <LedWizNumber>51</LedWizNumber>
+      <Outputs>
+        <LedWizEquivalentOutput>
+          <OutputName>Main Pinscape.08</OutputName>
+          <LedWizEquivalentOutputNumber>8</LedWizEquivalentOutputNumber>
+        </LedWizEquivalentOutput>
+      </Outputs>
+    </LedWizEquivalent>
+    
+    <!-- LedWizEquivalent for PinscapePico (Unit 1 = LedWiz #120) -->
+    <LedWizEquivalent>
+      <Name>Backbox Pico Equivalent</Name>
+      <LedWizNumber>120</LedWizNumber>
+      <Outputs>
+        <LedWizEquivalentOutput>
+          <OutputName>Backbox Pico.01</OutputName>
+          <LedWizEquivalentOutputNumber>1</LedWizEquivalentOutputNumber>
+        </LedWizEquivalentOutput>
+      </Outputs>
+    </LedWizEquivalent>
+  </Toys>
+  
+  <!-- Disable auto-configuration to use manual config -->
+  <AutoConfigEnabled>false</AutoConfigEnabled> 
+</Cabinet>
 ```

--- a/include/DOF/DOF.h
+++ b/include/DOF/DOF.h
@@ -2,7 +2,7 @@
 
 #define LIBDOF_VERSION_MAJOR 0 // X Digits
 #define LIBDOF_VERSION_MINOR 2 // Max 2 Digits
-#define LIBDOF_VERSION_PATCH 2 // Max 2 Digits
+#define LIBDOF_VERSION_PATCH 3 // Max 2 Digits
 
 #define _LIBDOF_STR(x) #x
 #define LIBDOF_STR(x) _LIBDOF_STR(x)

--- a/src/DirectOutputHandler.cpp
+++ b/src/DirectOutputHandler.cpp
@@ -19,7 +19,6 @@ namespace DOF
 
 std::string DirectOutputHandler::GetInstallFolder()
 {
-   // Get the full path to the running executable
    std::string executablePath;
 
 #ifdef _WIN32
@@ -49,19 +48,14 @@ std::string DirectOutputHandler::GetInstallFolder()
    if (executablePath.empty())
       return "";
 
-   // Get the directory path of the executable
    std::filesystem::path execPath(executablePath);
    std::string assemblyPath = execPath.parent_path().string();
 
-   // Check for the existence of a Config folder in this directory
    std::filesystem::path assemblyConfigPath = std::filesystem::path(assemblyPath) / "Config";
    std::filesystem::path assemblyParentConfigPath = std::filesystem::path(assemblyPath).parent_path() / "Config";
 
    if (!std::filesystem::exists(assemblyConfigPath) && std::filesystem::exists(assemblyParentConfigPath))
    {
-      // New configuration with binary subfolders - the executable is in
-      // a subfolder within the install folder, so the install folder
-      // is the parent of the executable folder
       std::string parent = std::filesystem::path(assemblyPath).parent_path().string();
       Log::Once("InstallFolderLoc",
          StringExtensions::Build("Install folder lookup: executable: {0}, install folder: {1} (PARENT of the executable folder -> new shared x86/x64 install)", executablePath, parent));
@@ -69,7 +63,6 @@ std::string DirectOutputHandler::GetInstallFolder()
    }
    else
    {
-      // Old flat configuration - the executable is in the install folder
       Log::Once("InstallFolderLoc",
          StringExtensions::Build("Install folder lookup: executable: {0}, install folder: {1} (EXECUTABLE folder -> original flat install configuration)", executablePath, assemblyPath));
       return assemblyPath;

--- a/src/cab/out/NullOutputController.cpp
+++ b/src/cab/out/NullOutputController.cpp
@@ -50,10 +50,11 @@ tinyxml2::XMLElement* NullOutputController::ToXml(tinyxml2::XMLDocument& doc) co
    tinyxml2::XMLElement* element = doc.NewElement(GetXmlElementName().c_str());
 
    if (!GetName().empty())
-      element->SetAttribute("Name", GetName().c_str());
-
-   element->SetAttribute("NumberOfOutputs", m_numberOfOutputs);
-   element->SetAttribute("LogOutputChanges", m_logOutputChanges);
+   {
+      tinyxml2::XMLElement* nameElement = doc.NewElement("Name");
+      nameElement->SetText(GetName().c_str());
+      element->InsertEndChild(nameElement);
+   }
 
    return element;
 }
@@ -66,12 +67,6 @@ bool NullOutputController::FromXml(const tinyxml2::XMLElement* element)
    const char* name = element->Attribute("Name");
    if (name)
       SetName(name);
-
-   int numberOfOutputs = m_numberOfOutputs;
-   element->QueryIntAttribute("NumberOfOutputs", &numberOfOutputs);
-   SetNumberOfOutputs(numberOfOutputs);
-
-   element->QueryBoolAttribute("LogOutputChanges", &m_logOutputChanges);
 
    return true;
 }

--- a/src/cab/out/OutputControllerCompleteBase.cpp
+++ b/src/cab/out/OutputControllerCompleteBase.cpp
@@ -154,7 +154,11 @@ tinyxml2::XMLElement* OutputControllerCompleteBase::ToXml(tinyxml2::XMLDocument&
    tinyxml2::XMLElement* element = doc.NewElement(GetXmlElementName().c_str());
 
    if (!GetName().empty())
-      element->SetAttribute("Name", GetName().c_str());
+   {
+      tinyxml2::XMLElement* nameElement = doc.NewElement("Name");
+      nameElement->SetText(GetName().c_str());
+      element->InsertEndChild(nameElement);
+   }
 
    return element;
 }
@@ -238,6 +242,7 @@ void OutputControllerCompleteBase::FinishUpdaterThread()
          if (future.wait_for(std::chrono::milliseconds(1000)) == std::future_status::timeout)
          {
             Log::Warning("Updater thread did not quit within timeout. Thread termination may be forceful.");
+            m_updaterThread->detach();
          }
 
          m_updaterThread.reset();

--- a/src/cab/out/OutputControllerFlexCompleteBase.cpp
+++ b/src/cab/out/OutputControllerFlexCompleteBase.cpp
@@ -1,4 +1,5 @@
 #include "OutputControllerFlexCompleteBase.h"
+#include <tinyxml2/tinyxml2.h>
 
 namespace DOF
 {
@@ -14,5 +15,38 @@ void OutputControllerFlexCompleteBase::SetNumberOfOutputs(int numberOfOutputs)
 }
 
 int OutputControllerFlexCompleteBase::GetNumberOfConfiguredOutputs() { return m_numberOfOutputs; }
+
+tinyxml2::XMLElement* OutputControllerFlexCompleteBase::ToXml(tinyxml2::XMLDocument& doc) const
+{
+   tinyxml2::XMLElement* element = OutputControllerCompleteBase::ToXml(doc);
+
+   tinyxml2::XMLElement* numberOfOutputsElement = doc.NewElement("NumberOfOutputs");
+   numberOfOutputsElement->SetText(m_numberOfOutputs);
+   element->InsertEndChild(numberOfOutputsElement);
+
+   return element;
+}
+
+bool OutputControllerFlexCompleteBase::FromXml(const tinyxml2::XMLElement* element)
+{
+   if (!OutputControllerCompleteBase::FromXml(element))
+      return false;
+
+   const tinyxml2::XMLElement* numberOfOutputsElement = element->FirstChildElement("NumberOfOutputs");
+   if (numberOfOutputsElement && numberOfOutputsElement->GetText())
+   {
+      try
+      {
+         int numberOfOutputs = std::stoi(numberOfOutputsElement->GetText());
+         SetNumberOfOutputs(numberOfOutputs);
+      }
+      catch (...)
+      {
+         return false;
+      }
+   }
+
+   return true;
+}
 
 }

--- a/src/cab/out/OutputControllerFlexCompleteBase.h
+++ b/src/cab/out/OutputControllerFlexCompleteBase.h
@@ -17,6 +17,9 @@ public:
 
    int GetNumberOfConfiguredOutputs() override;
 
+   virtual tinyxml2::XMLElement* ToXml(tinyxml2::XMLDocument& doc) const override;
+   virtual bool FromXml(const tinyxml2::XMLElement* element) override;
+
 private:
    int m_numberOfOutputs;
 };

--- a/src/cab/out/OutputControllerList.cpp
+++ b/src/cab/out/OutputControllerList.cpp
@@ -15,6 +15,7 @@
 #include "adressableledstrip/TeensyStripController.h"
 #include "adressableledstrip/WemosD1StripController.h"
 #include "comport/PinControl.h"
+#include "pinone/PinOne.h"
 #endif
 
 #ifdef __LIBFTDI__
@@ -110,6 +111,8 @@ IOutputController* OutputControllerList::CreateController(const std::string& typ
       return new WemosD1MPStripController();
    else if (typeName == "PinControl")
       return new PinControl();
+   else if (typeName == "PinOne")
+      return new PinOne();
 #endif
 #ifdef __LIBFTDI__
    else if (typeName == "FT245RBitbangController")

--- a/src/cab/out/adressableledstrip/DirectStripController.cpp
+++ b/src/cab/out/adressableledstrip/DirectStripController.cpp
@@ -246,4 +246,72 @@ void DirectStripController::UpdaterThreadDoIt()
    }
 }
 
+bool DirectStripController::FromXml(const tinyxml2::XMLElement* element)
+{
+   if (!element)
+      return false;
+
+   const char* name = element->Attribute("Name");
+   if (name)
+      SetName(name);
+
+   const tinyxml2::XMLElement* controllerNumberElement = element->FirstChildElement("ControllerNumber");
+   if (controllerNumberElement && controllerNumberElement->GetText())
+   {
+      try
+      {
+         int controllerNumber = std::stoi(controllerNumberElement->GetText());
+         SetControllerNumber(controllerNumber);
+      }
+      catch (...)
+      {
+         return false;
+      }
+   }
+
+   const tinyxml2::XMLElement* numberOfLedsElement = element->FirstChildElement("NumberOfLeds");
+   if (numberOfLedsElement && numberOfLedsElement->GetText())
+   {
+      try
+      {
+         int numberOfLeds = std::stoi(numberOfLedsElement->GetText());
+         SetNumberOfLeds(numberOfLeds);
+      }
+      catch (...)
+      {
+         return false;
+      }
+   }
+
+   const tinyxml2::XMLElement* packDataElement = element->FirstChildElement("PackData");
+   if (packDataElement && packDataElement->GetText())
+   {
+      SetPackData(std::string(packDataElement->GetText()) == "true");
+   }
+
+   return true;
+}
+
+tinyxml2::XMLElement* DirectStripController::ToXml(tinyxml2::XMLDocument& doc) const
+{
+   tinyxml2::XMLElement* element = doc.NewElement(GetXmlElementName().c_str());
+
+   if (!GetName().empty())
+      element->SetAttribute("Name", GetName().c_str());
+
+   tinyxml2::XMLElement* controllerNumberElement = doc.NewElement("ControllerNumber");
+   controllerNumberElement->SetText(m_controllerNumber);
+   element->InsertEndChild(controllerNumberElement);
+
+   tinyxml2::XMLElement* numberOfLedsElement = doc.NewElement("NumberOfLeds");
+   numberOfLedsElement->SetText(m_numberOfLeds);
+   element->InsertEndChild(numberOfLedsElement);
+
+   tinyxml2::XMLElement* packDataElement = doc.NewElement("PackData");
+   packDataElement->SetText(m_packData ? "true" : "false");
+   element->InsertEndChild(packDataElement);
+
+   return element;
+}
+
 }

--- a/src/cab/out/adressableledstrip/DirectStripController.h
+++ b/src/cab/out/adressableledstrip/DirectStripController.h
@@ -37,6 +37,8 @@ public:
    virtual void Update() override;
 
    virtual std::string GetXmlElementName() const override { return "DirectStripController"; }
+   virtual tinyxml2::XMLElement* ToXml(tinyxml2::XMLDocument& doc) const override;
+   virtual bool FromXml(const tinyxml2::XMLElement* element) override;
 
 protected:
    virtual void OnOutputValueChanged(IOutput* output) override;

--- a/src/cab/out/adressableledstrip/TeensyStripController.cpp
+++ b/src/cab/out/adressableledstrip/TeensyStripController.cpp
@@ -27,15 +27,7 @@ TeensyStripController::TeensyStripController()
 {
 }
 
-TeensyStripController::~TeensyStripController()
-{
-   if (m_comPort)
-   {
-      sp_close(m_comPort);
-      sp_free_port(m_comPort);
-      m_comPort = nullptr;
-   }
-}
+TeensyStripController::~TeensyStripController() { DisconnectFromController(); }
 
 void TeensyStripController::SetNumberOfLedsStrip1(int value)
 {
@@ -393,7 +385,7 @@ void TeensyStripController::ConnectToController()
                                       "Open {6}ms, Loop Start/End {7}/{8}ms, DTR enable {9}",
       std::vector<std::string> { m_comPortName, std::to_string(m_comPortBaudRate), std::to_string((int)m_comPortParity), std::to_string(m_comPortDataBits),
          std::to_string((int)m_comPortStopBits), std::to_string(m_comPortTimeOutMs), std::to_string(m_comPortOpenWaitMs), std::to_string(m_comPortHandshakeStartWaitMs),
-         std::to_string(m_comPortHandshakeEndWaitMs), std::to_string(m_comPortDtrEnable) }));
+         std::to_string(m_comPortHandshakeEndWaitMs), m_comPortDtrEnable ? "true" : "false" }));
 
    result = sp_get_port_by_name(m_comPortName.c_str(), &m_comPort);
    if (result != SP_OK)
@@ -434,7 +426,8 @@ void TeensyStripController::ConnectToController()
       sp_set_dtr(m_comPort, SP_DTR_OFF);
 
    std::this_thread::sleep_for(std::chrono::milliseconds(m_comPortOpenWaitMs));
-   sp_flush(m_comPort, SP_BUF_INPUT);
+   sp_flush(m_comPort, SP_BUF_BOTH);
+   std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
    bool commandModeOK = false;
    for (int attemptNr = 0; attemptNr < 20; attemptNr++)
@@ -646,6 +639,106 @@ bool TeensyStripController::FromXml(const tinyxml2::XMLElement* element)
    loadElement("NumberOfLedsStrip10", [this](const char* text) { SetNumberOfLedsStrip10(std::stoi(text)); });
 
    return true;
+}
+
+tinyxml2::XMLElement* TeensyStripController::ToXml(tinyxml2::XMLDocument& doc) const
+{
+   tinyxml2::XMLElement* element = OutputControllerCompleteBase::ToXml(doc);
+
+   tinyxml2::XMLElement* numberOfLedsStrip1Element = doc.NewElement("NumberOfLedsStrip1");
+   numberOfLedsStrip1Element->SetText(GetNumberOfLedsStrip1());
+   element->InsertEndChild(numberOfLedsStrip1Element);
+
+   tinyxml2::XMLElement* numberOfLedsStrip2Element = doc.NewElement("NumberOfLedsStrip2");
+   numberOfLedsStrip2Element->SetText(GetNumberOfLedsStrip2());
+   element->InsertEndChild(numberOfLedsStrip2Element);
+
+   tinyxml2::XMLElement* numberOfLedsStrip3Element = doc.NewElement("NumberOfLedsStrip3");
+   numberOfLedsStrip3Element->SetText(GetNumberOfLedsStrip3());
+   element->InsertEndChild(numberOfLedsStrip3Element);
+
+   tinyxml2::XMLElement* numberOfLedsStrip4Element = doc.NewElement("NumberOfLedsStrip4");
+   numberOfLedsStrip4Element->SetText(GetNumberOfLedsStrip4());
+   element->InsertEndChild(numberOfLedsStrip4Element);
+
+   tinyxml2::XMLElement* numberOfLedsStrip5Element = doc.NewElement("NumberOfLedsStrip5");
+   numberOfLedsStrip5Element->SetText(GetNumberOfLedsStrip5());
+   element->InsertEndChild(numberOfLedsStrip5Element);
+
+   tinyxml2::XMLElement* numberOfLedsStrip6Element = doc.NewElement("NumberOfLedsStrip6");
+   numberOfLedsStrip6Element->SetText(GetNumberOfLedsStrip6());
+   element->InsertEndChild(numberOfLedsStrip6Element);
+
+   tinyxml2::XMLElement* numberOfLedsStrip7Element = doc.NewElement("NumberOfLedsStrip7");
+   numberOfLedsStrip7Element->SetText(GetNumberOfLedsStrip7());
+   element->InsertEndChild(numberOfLedsStrip7Element);
+
+   tinyxml2::XMLElement* numberOfLedsStrip8Element = doc.NewElement("NumberOfLedsStrip8");
+   numberOfLedsStrip8Element->SetText(GetNumberOfLedsStrip8());
+   element->InsertEndChild(numberOfLedsStrip8Element);
+
+   tinyxml2::XMLElement* numberOfLedsStrip9Element = doc.NewElement("NumberOfLedsStrip9");
+   numberOfLedsStrip9Element->SetText(GetNumberOfLedsStrip9());
+   element->InsertEndChild(numberOfLedsStrip9Element);
+
+   tinyxml2::XMLElement* numberOfLedsStrip10Element = doc.NewElement("NumberOfLedsStrip10");
+   numberOfLedsStrip10Element->SetText(GetNumberOfLedsStrip10());
+   element->InsertEndChild(numberOfLedsStrip10Element);
+
+   tinyxml2::XMLElement* comPortNameElement = doc.NewElement("ComPortName");
+   comPortNameElement->SetText(GetComPortName().c_str());
+   element->InsertEndChild(comPortNameElement);
+
+   tinyxml2::XMLElement* comPortBaudRateElement = doc.NewElement("ComPortBaudRate");
+   comPortBaudRateElement->SetText(GetComPortBaudRate());
+   element->InsertEndChild(comPortBaudRateElement);
+
+   tinyxml2::XMLElement* comPortParityElement = doc.NewElement("ComPortParity");
+   switch (GetComPortParity())
+   {
+   case Parity::None: comPortParityElement->SetText("None"); break;
+   case Parity::Odd: comPortParityElement->SetText("Odd"); break;
+   case Parity::Even: comPortParityElement->SetText("Even"); break;
+   case Parity::Mark: comPortParityElement->SetText("Mark"); break;
+   case Parity::Space: comPortParityElement->SetText("Space"); break;
+   }
+   element->InsertEndChild(comPortParityElement);
+
+   tinyxml2::XMLElement* comPortDataBitsElement = doc.NewElement("ComPortDataBits");
+   comPortDataBitsElement->SetText(GetComPortDataBits());
+   element->InsertEndChild(comPortDataBitsElement);
+
+   tinyxml2::XMLElement* comPortStopBitsElement = doc.NewElement("ComPortStopBits");
+   switch (GetComPortStopBits())
+   {
+   case StopBits::None: comPortStopBitsElement->SetText("None"); break;
+   case StopBits::One: comPortStopBitsElement->SetText("One"); break;
+   case StopBits::Two: comPortStopBitsElement->SetText("Two"); break;
+   case StopBits::OnePointFive: comPortStopBitsElement->SetText("OnePointFive"); break;
+   }
+   element->InsertEndChild(comPortStopBitsElement);
+
+   tinyxml2::XMLElement* comPortTimeOutMsElement = doc.NewElement("ComPortTimeOutMs");
+   comPortTimeOutMsElement->SetText(GetComPortTimeOutMs());
+   element->InsertEndChild(comPortTimeOutMsElement);
+
+   tinyxml2::XMLElement* comPortOpenWaitMsElement = doc.NewElement("ComPortOpenWaitMs");
+   comPortOpenWaitMsElement->SetText(GetComPortOpenWaitMs());
+   element->InsertEndChild(comPortOpenWaitMsElement);
+
+   tinyxml2::XMLElement* comPortHandshakeStartWaitMsElement = doc.NewElement("ComPortHandshakeStartWaitMs");
+   comPortHandshakeStartWaitMsElement->SetText(GetComPortHandshakeStartWaitMs());
+   element->InsertEndChild(comPortHandshakeStartWaitMsElement);
+
+   tinyxml2::XMLElement* comPortHandshakeEndWaitMsElement = doc.NewElement("ComPortHandshakeEndWaitMs");
+   comPortHandshakeEndWaitMsElement->SetText(GetComPortHandshakeEndWaitMs());
+   element->InsertEndChild(comPortHandshakeEndWaitMsElement);
+
+   tinyxml2::XMLElement* comPortDtrEnableElement = doc.NewElement("ComPortDtrEnable");
+   comPortDtrEnableElement->SetText(GetComPortDtrEnable() ? "true" : "false");
+   element->InsertEndChild(comPortDtrEnableElement);
+
+   return element;
 }
 
 }

--- a/src/cab/out/adressableledstrip/TeensyStripController.h
+++ b/src/cab/out/adressableledstrip/TeensyStripController.h
@@ -97,6 +97,7 @@ public:
 
    virtual std::string GetXmlElementName() const override { return "TeensyStripController"; }
 
+   virtual tinyxml2::XMLElement* ToXml(tinyxml2::XMLDocument& doc) const override;
    virtual bool FromXml(const tinyxml2::XMLElement* element) override;
 
 protected:
@@ -111,6 +112,7 @@ protected:
    int ReadPortWait(uint8_t* buffer, int bufferOffset, int numberOfBytes);
 
    const std::vector<int>& GetNumberOfLedsPerStrip() const { return m_numberOfLedsPerStrip; }
+   int GetNumberOfLedsPerChannel() const { return m_numberOfLedsPerChannel; }
    struct sp_port* GetComPort() const { return m_comPort; }
 
 private:

--- a/src/cab/out/adressableledstrip/WemosD1StripController.h
+++ b/src/cab/out/adressableledstrip/WemosD1StripController.h
@@ -24,18 +24,21 @@ public:
    void SetTestOnConnect(bool value) { m_testOnConnect = value; }
 
    virtual std::string GetXmlElementName() const override { return "WemosD1MPStripController"; }
+   virtual tinyxml2::XMLElement* ToXml(tinyxml2::XMLDocument& doc) const override;
+   virtual bool FromXml(const tinyxml2::XMLElement* element) override;
 
 protected:
    virtual void SetupController() override;
    virtual void SendLedstripData(const std::vector<uint8_t>& outputValues, int targetPosition) override;
 
+protected:
+   std::vector<uint8_t> m_compressedData;
+   std::vector<uint8_t> m_uncompressedData;
+
 private:
    bool m_sendPerLedstripLength;
    bool m_useCompression;
    bool m_testOnConnect;
-
-   std::vector<uint8_t> m_compressedData;
-   std::vector<uint8_t> m_uncompressedData;
 };
 
 }

--- a/src/cab/out/comport/PinControl.h
+++ b/src/cab/out/comport/PinControl.h
@@ -3,10 +3,7 @@
 #include "../OutputControllerCompleteBase.h"
 #include <string>
 #include <mutex>
-
-#ifdef __LIBSERIALPORT__
 #include <libserialport.h>
-#endif
 
 namespace DOF
 {
@@ -26,6 +23,8 @@ public:
    virtual void Finish() override;
 
    virtual std::string GetXmlElementName() const override { return "PinControl"; }
+   virtual tinyxml2::XMLElement* ToXml(tinyxml2::XMLDocument& doc) const override;
+   virtual bool FromXml(const tinyxml2::XMLElement* element) override;
 
 protected:
    virtual int GetNumberOfConfiguredOutputs() override;
@@ -38,12 +37,7 @@ private:
    std::string m_comPort;
    uint8_t* m_oldValues;
    std::mutex m_portLocker;
-
-#ifdef __LIBSERIALPORT__
    struct sp_port* m_port;
-#else
-   void* m_port;
-#endif
 };
 
 }

--- a/src/cab/out/dmx/ArtNet.cpp
+++ b/src/cab/out/dmx/ArtNet.cpp
@@ -95,4 +95,50 @@ void ArtNet::DisconnectFromController()
    }
 }
 
+bool ArtNet::FromXml(const tinyxml2::XMLElement* element)
+{
+   if (!OutputControllerCompleteBase::FromXml(element))
+      return false;
+
+   const tinyxml2::XMLElement* universeElement = element->FirstChildElement("Universe");
+   if (universeElement && universeElement->GetText())
+   {
+      try
+      {
+         int universe = std::stoi(universeElement->GetText());
+         SetUniverse(static_cast<short>(universe));
+      }
+      catch (...)
+      {
+         return false;
+      }
+   }
+
+   const tinyxml2::XMLElement* broadcastElement = element->FirstChildElement("BroadcastAddress");
+   if (broadcastElement && broadcastElement->GetText())
+   {
+      SetBroadcastAddress(broadcastElement->GetText());
+   }
+
+   return true;
+}
+
+tinyxml2::XMLElement* ArtNet::ToXml(tinyxml2::XMLDocument& doc) const
+{
+   tinyxml2::XMLElement* element = OutputControllerCompleteBase::ToXml(doc);
+
+   tinyxml2::XMLElement* universeElement = doc.NewElement("Universe");
+   universeElement->SetText(m_universe);
+   element->InsertEndChild(universeElement);
+
+   if (!m_broadcastAddress.empty())
+   {
+      tinyxml2::XMLElement* broadcastElement = doc.NewElement("BroadcastAddress");
+      broadcastElement->SetText(m_broadcastAddress.c_str());
+      element->InsertEndChild(broadcastElement);
+   }
+
+   return element;
+}
+
 }

--- a/src/cab/out/dmx/ArtNet.h
+++ b/src/cab/out/dmx/ArtNet.h
@@ -21,6 +21,8 @@ public:
    void SetBroadcastAddress(const std::string& value) { m_broadcastAddress = value; }
 
    virtual std::string GetXmlElementName() const override { return "ArtNet"; }
+   virtual tinyxml2::XMLElement* ToXml(tinyxml2::XMLDocument& doc) const override;
+   virtual bool FromXml(const tinyxml2::XMLElement* element) override;
 
 protected:
    virtual int GetNumberOfConfiguredOutputs() override;

--- a/src/cab/out/dmx/artnetengine/Engine.cpp
+++ b/src/cab/out/dmx/artnetengine/Engine.cpp
@@ -37,7 +37,7 @@ Engine::Engine()
    , m_socketInitialized(false)
    , m_sendExceptionCount(0)
 {
-   m_artNetHeader = { 0x41, 0x72, 0x74, 0x2d, 0x4e, 0x65, 0x74, 0 }; // "Art-Net"
+   m_artNetHeader = { 0x41, 0x72, 0x74, 0x2d, 0x4e, 0x65, 0x74, 0 };
 
 #ifdef _WIN32
    WSADATA wsaData;
@@ -98,7 +98,7 @@ bool Engine::InitializeSocket()
 #else
       struct timeval timeout;
       timeout.tv_sec = 0;
-      timeout.tv_usec = 100000; // 100ms
+      timeout.tv_usec = 100000;
       if (setsockopt(m_socket, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout)) < 0)
       {
          Log::Exception("Could not set send timeout for ArtNet socket");
@@ -143,30 +143,23 @@ void Engine::SendDMX(const std::string& broadcastAddress, short universe, const 
 
    std::vector<uint8_t> packet(0x12 + dataLength);
 
-   // Copy ArtNet header
    std::memcpy(packet.data(), m_artNetHeader.data(), m_artNetHeader.size());
 
-   // OpCode (0x5000 for DMX data)
    packet[8] = LoByte(0x5000);
    packet[9] = HiByte(0x5000);
 
-   // Protocol version
-   packet[10] = 0; // ProtVerHi
-   packet[11] = 14; // ProtVerLo
+   packet[10] = 0;
+   packet[11] = 14;
 
-   // Sequence and Physical
-   packet[12] = 0; // Sequence
-   packet[13] = 0; // Physical
+   packet[12] = 0;
+   packet[13] = 0;
 
-   // Universe
    packet[14] = LoByte(universe);
    packet[15] = HiByte(universe);
 
-   // Data length
    packet[16] = HiByte(dataLength);
    packet[17] = LoByte(dataLength);
 
-   // Copy DMX data
    try
    {
       std::memcpy(packet.data() + 0x12, data.data(), dataLength);

--- a/src/cab/out/dudescab/DudesCab.h
+++ b/src/cab/out/dudescab/DudesCab.h
@@ -35,6 +35,8 @@ public:
    virtual void Finish() override;
 
    virtual std::string GetXmlElementName() const override { return "DudesCab"; }
+   virtual tinyxml2::XMLElement* ToXml(tinyxml2::XMLDocument& doc) const override;
+   virtual bool FromXml(const tinyxml2::XMLElement* element) override;
 
    class Device
    {

--- a/src/cab/out/dudescab/DudesCabAutoConfigurator.cpp
+++ b/src/cab/out/dudescab/DudesCabAutoConfigurator.cpp
@@ -29,8 +29,6 @@ void DudesCabAutoConfigurator::AutoConfig(Cabinet* cabinet)
 
             Log::Write(StringExtensions::Build("Detected and added DudesCab Controller {0} with {1} outputs", controllerName, std::to_string(device->NumOutputs())));
 
-            // Create LedWizEquivalent for DOF config compatibility
-            // DudesCab controllers are registered as units 90-94 in DOF config
             int ledWizNumber = 90 + device->UnitNo() - 1;
 
             bool foundExistingToy = false;
@@ -52,7 +50,6 @@ void DudesCabAutoConfigurator::AutoConfig(Cabinet* cabinet)
                lwe->SetLedWizNumber(ledWizNumber);
                lwe->SetName(StringExtensions::Build("{0} Equivalent 1", controllerName));
 
-               // Create outputs for all available outputs on the DudesCab
                for (int outputIndex = 1; outputIndex <= device->NumOutputs(); outputIndex++)
                {
                   LedWizEquivalentOutput* lweo = new LedWizEquivalentOutput();

--- a/src/cab/out/lw/LedWiz.cpp
+++ b/src/cab/out/lw/LedWiz.cpp
@@ -2,6 +2,7 @@
 #include "../../../Log.h"
 #include "../../../general/StringExtensions.h"
 #include "../../Cabinet.h"
+#include "../Output.h"
 
 #include <algorithm>
 #include <cstdint>
@@ -102,9 +103,29 @@ void LedWiz::Update() { }
 
 void LedWiz::AddOutputs()
 {
+   OutputList* outputs = GetOutputs();
+   if (!outputs)
+      return;
+
    for (int i = 1; i <= 32; i++)
    {
-      // Simplified for C++ - just placeholder until proper output system is implemented
+      bool found = false;
+      for (auto* output : *outputs)
+      {
+         if (output->GetNumber() == i)
+         {
+            found = true;
+            break;
+         }
+      }
+
+      if (!found)
+      {
+         Output* newOutput = new Output();
+         newOutput->SetName(StringExtensions::Build("{0}.{1:00}", GetName(), std::to_string(i)));
+         newOutput->SetNumber(i);
+         outputs->push_back(newOutput);
+      }
    }
 }
 

--- a/src/cab/out/pinone/NamedPipeServer.cpp
+++ b/src/cab/out/pinone/NamedPipeServer.cpp
@@ -1,0 +1,264 @@
+#include "NamedPipeServer.h"
+#include "../../../general/StringExtensions.h"
+#include <thread>
+#include <vector>
+#include <stdexcept>
+#include <chrono>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <cstring>
+#endif
+
+namespace DOF
+{
+
+const std::string NamedPipeServer::s_pipeName = "ComPortServerPipe";
+
+NamedPipeServer::NamedPipeServer(const std::string& comPort)
+   : m_comPort(comPort)
+{
+   sp_get_port_by_name(comPort.c_str(), &m_serialPort);
+   if (m_serialPort)
+   {
+      sp_open(m_serialPort, SP_MODE_READ_WRITE);
+      sp_set_baudrate(m_serialPort, 2000000);
+      sp_set_bits(m_serialPort, 8);
+      sp_set_parity(m_serialPort, SP_PARITY_NONE);
+      sp_set_stopbits(m_serialPort, 1);
+      sp_set_rts(m_serialPort, SP_RTS_ON);
+      sp_set_dtr(m_serialPort, SP_DTR_ON);
+   }
+}
+
+NamedPipeServer::~NamedPipeServer()
+{
+   StopServer();
+   if (m_serialPort)
+   {
+      sp_close(m_serialPort);
+      sp_free_port(m_serialPort);
+   }
+}
+
+void NamedPipeServer::StartServer()
+{
+   m_serverThread = std::thread(
+      [this]()
+      {
+         while (m_isRunning)
+         {
+#ifdef _WIN32
+            std::string pipePath = "\\\\.\\pipe\\" + s_pipeName;
+            HANDLE serverPipe = CreateNamedPipeA(pipePath.c_str(), PIPE_ACCESS_DUPLEX, PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT, PIPE_UNLIMITED_INSTANCES, 1024, 1024, 0, nullptr);
+
+            if (serverPipe == INVALID_HANDLE_VALUE)
+            {
+               continue;
+            }
+
+            if (ConnectNamedPipe(serverPipe, nullptr) || GetLastError() == ERROR_PIPE_CONNECTED)
+            {
+               HandleClientConnection(serverPipe);
+            }
+
+            CloseHandle(serverPipe);
+#else
+            int serverSock = socket(AF_UNIX, SOCK_STREAM, 0);
+            if (serverSock < 0)
+            {
+               continue;
+            }
+
+            struct sockaddr_un addr;
+            memset(&addr, 0, sizeof(addr));
+            addr.sun_family = AF_UNIX;
+            std::string sockPath = "/tmp/" + s_pipeName;
+            strncpy(addr.sun_path, sockPath.c_str(), sizeof(addr.sun_path) - 1);
+
+            unlink(sockPath.c_str());
+
+            if (bind(serverSock, (struct sockaddr*)&addr, sizeof(addr)) < 0)
+            {
+               close(serverSock);
+               continue;
+            }
+
+            if (listen(serverSock, 1) < 0)
+            {
+               close(serverSock);
+               continue;
+            }
+
+            int clientSock = accept(serverSock, nullptr, nullptr);
+            if (clientSock >= 0)
+            {
+               HandleClientConnection(reinterpret_cast<void*>(static_cast<intptr_t>(clientSock)));
+               close(clientSock);
+            }
+
+            close(serverSock);
+            unlink(sockPath.c_str());
+#endif
+         }
+      });
+}
+
+void NamedPipeServer::HandleClientConnection(void* serverStream)
+{
+   bool completed = false;
+
+   while (m_isRunning && !completed)
+   {
+      try
+      {
+         std::vector<char> request(1024);
+         int bytesRead = 0;
+
+#ifdef _WIN32
+         HANDLE pipe = static_cast<HANDLE>(serverStream);
+         DWORD dwBytesRead;
+         if (!ReadFile(pipe, request.data(), static_cast<DWORD>(request.size()), &dwBytesRead, nullptr))
+         {
+            break;
+         }
+         bytesRead = static_cast<int>(dwBytesRead);
+#else
+         int sock = static_cast<int>(reinterpret_cast<intptr_t>(serverStream));
+         bytesRead = static_cast<int>(read(sock, request.data(), request.size()));
+         if (bytesRead <= 0)
+         {
+            break;
+         }
+#endif
+
+         std::string requestStr(request.data(), bytesRead);
+
+         if (StringExtensions::StartsWith(requestStr, "CONNECT"))
+         {
+            if (m_serialPort && sp_get_port_handle(m_serialPort, nullptr) == SP_OK)
+            {
+               sp_open(m_serialPort, SP_MODE_READ_WRITE);
+            }
+            std::string response = "OK";
+#ifdef _WIN32
+            HANDLE pipe = static_cast<HANDLE>(serverStream);
+            DWORD bytesWritten;
+            WriteFile(pipe, response.c_str(), static_cast<DWORD>(response.length()), &bytesWritten, nullptr);
+#else
+            int sock = static_cast<int>(reinterpret_cast<intptr_t>(serverStream));
+            write(sock, response.c_str(), response.length());
+#endif
+         }
+         else if (StringExtensions::StartsWith(requestStr, "STOP_SERVER"))
+         {
+            m_isRunning = false;
+         }
+         else if (StringExtensions::StartsWith(requestStr, "DISCONNECT"))
+         {
+            completed = true;
+         }
+         else if (StringExtensions::StartsWith(requestStr, "WRITE"))
+         {
+            std::string base64Data = requestStr.substr(6);
+            std::vector<uint8_t> bytesToWrite = StringExtensions::FromBase64(base64Data);
+
+            if (m_serialPort)
+            {
+               sp_blocking_write(m_serialPort, bytesToWrite.data(), bytesToWrite.size(), 500);
+            }
+
+            std::string response = "OK";
+#ifdef _WIN32
+            HANDLE pipe = static_cast<HANDLE>(serverStream);
+            DWORD bytesWritten;
+            WriteFile(pipe, response.c_str(), static_cast<DWORD>(response.length()), &bytesWritten, nullptr);
+#else
+            int sock = static_cast<int>(reinterpret_cast<intptr_t>(serverStream));
+            write(sock, response.c_str(), response.length());
+#endif
+         }
+         else if (StringExtensions::StartsWith(requestStr, "READLINE"))
+         {
+            std::string response;
+            if (m_serialPort)
+            {
+               char buffer[256];
+               int bytesRead = sp_blocking_read(m_serialPort, buffer, sizeof(buffer) - 1, 500);
+               if (bytesRead > 0)
+               {
+                  buffer[bytesRead] = '\0';
+                  response = buffer;
+               }
+            }
+
+#ifdef _WIN32
+            HANDLE pipe = static_cast<HANDLE>(serverStream);
+            DWORD bytesWritten;
+            WriteFile(pipe, response.c_str(), static_cast<DWORD>(response.length()), &bytesWritten, nullptr);
+#else
+            int sock = static_cast<int>(reinterpret_cast<intptr_t>(serverStream));
+            write(sock, response.c_str(), response.length());
+#endif
+         }
+         else if (StringExtensions::StartsWith(requestStr, "CHECK"))
+         {
+            std::string response = "FALSE";
+            if (m_serialPort)
+            {
+               void* handle;
+               if (sp_get_port_handle(m_serialPort, &handle) == SP_OK && handle != nullptr)
+               {
+                  response = "TRUE";
+               }
+            }
+
+#ifdef _WIN32
+            HANDLE pipe = static_cast<HANDLE>(serverStream);
+            DWORD bytesWritten;
+            WriteFile(pipe, response.c_str(), static_cast<DWORD>(response.length()), &bytesWritten, nullptr);
+#else
+            int sock = static_cast<int>(reinterpret_cast<intptr_t>(serverStream));
+            write(sock, response.c_str(), response.length());
+#endif
+         }
+         else if (StringExtensions::StartsWith(requestStr, "COMPORT"))
+         {
+#ifdef _WIN32
+            HANDLE pipe = static_cast<HANDLE>(serverStream);
+            DWORD bytesWritten;
+            WriteFile(pipe, m_comPort.c_str(), static_cast<DWORD>(m_comPort.length()), &bytesWritten, nullptr);
+#else
+            int sock = static_cast<int>(reinterpret_cast<intptr_t>(serverStream));
+            write(sock, m_comPort.c_str(), m_comPort.length());
+#endif
+         }
+      }
+      catch (...)
+      {
+         completed = true;
+      }
+   }
+}
+
+void NamedPipeServer::StopServer()
+{
+   m_isRunning = false;
+   if (m_serverThread.joinable())
+   {
+      m_serverThread.join();
+   }
+
+   if (m_serialPort)
+   {
+      sp_close(m_serialPort);
+   }
+
+   std::this_thread::sleep_for(std::chrono::milliseconds(300));
+}
+
+}

--- a/src/cab/out/pinone/NamedPipeServer.h
+++ b/src/cab/out/pinone/NamedPipeServer.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <string>
+#include <atomic>
+#include <thread>
+
+#include <libserialport.h>
+
+namespace DOF
+{
+
+class NamedPipeServer
+{
+private:
+   std::atomic<bool> m_isRunning { true };
+   std::string m_comPort;
+   static const std::string s_pipeName;
+   std::thread m_serverThread;
+   struct sp_port* m_serialPort = nullptr;
+
+   void HandleClientConnection(void* serverStream);
+
+public:
+   NamedPipeServer(const std::string& comPort);
+   ~NamedPipeServer();
+
+   void StartServer();
+   void StopServer();
+};
+
+}

--- a/src/cab/out/pinone/PinOne.cpp
+++ b/src/cab/out/pinone/PinOne.cpp
@@ -1,0 +1,256 @@
+#include "PinOne.h"
+#include "PinOneCommunication.h"
+#include "../../Cabinet.h"
+#include "../../../general/StringExtensions.h"
+#include "../../../general/MathExtensions.h"
+#include "../../../Log.h"
+#include <algorithm>
+#include <thread>
+#include <cmath>
+
+namespace DOF
+{
+
+PinOne::PinOne()
+{
+   SetComPort("");
+   SetNumber(1);
+}
+
+PinOne::PinOne(const std::string& comPort)
+{
+   SetComPort(comPort);
+   SetNumber(1);
+}
+
+PinOne::~PinOne()
+{
+   if (m_pinOneCommunication)
+   {
+      delete m_pinOneCommunication;
+      m_pinOneCommunication = nullptr;
+   }
+}
+
+void PinOne::SetNumber(int value)
+{
+   if (!MathExtensions::IsBetween(value, 1, 16))
+      throw std::runtime_error(StringExtensions::Build("PinOne Unit Numbers must be between 1-16. The supplied number {0} is out of range.", std::to_string(value)));
+
+   std::lock_guard<std::mutex> lock(m_numberUpdateLocker);
+
+   if (m_number != value)
+   {
+      if (GetName().empty() || GetName() == StringExtensions::Build("PinOne Controller {0:00}", std::to_string(m_number)))
+      {
+         SetName(StringExtensions::Build("PinOne Controller {0:00}", StringExtensions::FormatNumber(value, 2)));
+      }
+
+      m_number = value;
+
+      SetNumberOfOutputs(63);
+      m_oldOutputValues.assign(GetNumberOfOutputs(), 255);
+   }
+}
+
+void PinOne::SetMinCommandIntervalMs(int value)
+{
+   m_minCommandIntervalMs = MathExtensions::Limit(value, 0, 1000);
+   m_minCommandIntervalMsSet = true;
+}
+
+void PinOne::SetComPort(const std::string& value)
+{
+   m_comPort = value;
+   m_comPortSet = true;
+}
+
+void PinOne::Init(Cabinet* cabinet)
+{
+   if (!m_minCommandIntervalMsSet && cabinet->GetOwner()->GetConfigurationSettings().find("PinOneDefaultMinCommandIntervalMs") != cabinet->GetOwner()->GetConfigurationSettings().end())
+   {
+      auto it = cabinet->GetOwner()->GetConfigurationSettings().find("PinOneDefaultMinCommandIntervalMs");
+      if (it != cabinet->GetOwner()->GetConfigurationSettings().end())
+      {
+         try
+         {
+            SetMinCommandIntervalMs(std::stoi(it->second));
+         }
+         catch (...)
+         {
+         }
+      }
+   }
+
+   if (!m_comPortSet && cabinet->GetOwner()->GetConfigurationSettings().find("PinOneComPort") != cabinet->GetOwner()->GetConfigurationSettings().end())
+   {
+      auto it = cabinet->GetOwner()->GetConfigurationSettings().find("PinOneComPort");
+      if (it != cabinet->GetOwner()->GetConfigurationSettings().end())
+         SetComPort(it->second);
+   }
+
+   OutputControllerFlexCompleteBase::Init(cabinet);
+}
+
+void PinOne::Finish() { OutputControllerFlexCompleteBase::Finish(); }
+
+bool PinOne::VerifySettings()
+{
+   if (StringExtensions::IsNullOrWhiteSpace(m_comPort))
+   {
+      Log::Warning(StringExtensions::Build("ComPort is not set for {0} {1}.", "PinOne", GetName()));
+      return false;
+   }
+
+   return true;
+}
+
+void PinOne::UpdateOutputs(const std::vector<uint8_t>& newOutputValues)
+{
+   uint8_t pfx = 200;
+   for (int i = 0; i < GetNumberOfOutputs(); i += 7, ++pfx)
+   {
+      int lim = std::min(i + 7, GetNumberOfOutputs());
+      for (int j = i; j < lim; ++j)
+      {
+         if (newOutputValues[j] != m_oldOutputValues[j])
+         {
+            UpdateDelay();
+            std::vector<uint8_t> buf(9);
+            buf[0] = 0;
+            buf[1] = pfx;
+            std::copy(newOutputValues.begin() + i, newOutputValues.begin() + lim, buf.begin() + 2);
+
+            if (m_pinOneCommunication)
+               m_pinOneCommunication->Write(buf);
+
+            std::copy(newOutputValues.begin() + i, newOutputValues.begin() + lim, m_oldOutputValues.begin() + i);
+            break;
+         }
+      }
+   }
+}
+
+void PinOne::UpdateDelay()
+{
+   auto now = std::chrono::steady_clock::now();
+   auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - m_lastUpdate).count();
+
+   if (elapsed < m_minCommandIntervalMs)
+   {
+      int sleepMs = MathExtensions::Limit(static_cast<int>(m_minCommandIntervalMs - elapsed), 0, m_minCommandIntervalMs);
+      std::this_thread::sleep_for(std::chrono::milliseconds(sleepMs));
+   }
+   m_lastUpdate = std::chrono::steady_clock::now();
+}
+
+void PinOne::ConnectToController()
+{
+   try
+   {
+      std::lock_guard<std::mutex> lock(m_portLocker);
+
+      if (m_pinOneCommunication)
+         DisconnectFromController();
+
+      m_pinOneCommunication = new PinOneCommunication(m_comPort);
+      if (!m_pinOneCommunication->ConnectToServer())
+      {
+         if (m_pinOneCommunication->CreateServer())
+         {
+            if (!m_pinOneCommunication->ConnectToServer())
+            {
+               Log::Warning(StringExtensions::Build("Unable to connect to PinOne on comport {0}", m_comPort));
+               return;
+            }
+         }
+         else
+         {
+            Log::Warning(StringExtensions::Build("Unable to create PinOne server for comport {0}", m_comPort));
+            return;
+         }
+      }
+   }
+   catch (const std::exception& e)
+   {
+      std::string msg = StringExtensions::Build("A exception occurred while opening comport {0} for {1}.", m_comPort, GetName());
+      Log::Warning(msg);
+   }
+}
+
+void PinOne::DisconnectFromController()
+{
+   std::lock_guard<std::mutex> lock(m_portLocker);
+
+   if (m_pinOneCommunication)
+   {
+      m_pinOneCommunication->DisconnectFromServer();
+      delete m_pinOneCommunication;
+      m_pinOneCommunication = nullptr;
+   }
+}
+
+bool PinOne::FromXml(const tinyxml2::XMLElement* element)
+{
+   if (!OutputControllerFlexCompleteBase::FromXml(element))
+      return false;
+
+   const tinyxml2::XMLElement* numberElement = element->FirstChildElement("Number");
+   if (numberElement && numberElement->GetText())
+   {
+      try
+      {
+         int number = std::stoi(numberElement->GetText());
+         SetNumber(number);
+      }
+      catch (...)
+      {
+         return false;
+      }
+   }
+
+   const tinyxml2::XMLElement* intervalElement = element->FirstChildElement("MinCommandIntervalMs");
+   if (intervalElement && intervalElement->GetText())
+   {
+      try
+      {
+         int interval = std::stoi(intervalElement->GetText());
+         SetMinCommandIntervalMs(interval);
+      }
+      catch (...)
+      {
+      }
+   }
+
+   const tinyxml2::XMLElement* comPortElement = element->FirstChildElement("ComPort");
+   if (comPortElement && comPortElement->GetText())
+   {
+      SetComPort(comPortElement->GetText());
+   }
+
+   return true;
+}
+
+tinyxml2::XMLElement* PinOne::ToXml(tinyxml2::XMLDocument& doc) const
+{
+   tinyxml2::XMLElement* element = OutputControllerFlexCompleteBase::ToXml(doc);
+
+   tinyxml2::XMLElement* numberElement = doc.NewElement("Number");
+   numberElement->SetText(m_number);
+   element->InsertEndChild(numberElement);
+
+   tinyxml2::XMLElement* intervalElement = doc.NewElement("MinCommandIntervalMs");
+   intervalElement->SetText(m_minCommandIntervalMs);
+   element->InsertEndChild(intervalElement);
+
+   if (!m_comPort.empty())
+   {
+      tinyxml2::XMLElement* comPortElement = doc.NewElement("ComPort");
+      comPortElement->SetText(m_comPort.c_str());
+      element->InsertEndChild(comPortElement);
+   }
+
+   return element;
+}
+
+}

--- a/src/cab/out/pinone/PinOne.h
+++ b/src/cab/out/pinone/PinOne.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "../OutputControllerFlexCompleteBase.h"
+#include <string>
+#include <mutex>
+#include <vector>
+#include <cstdint>
+#include <chrono>
+
+namespace DOF
+{
+
+class Cabinet;
+class PinOneCommunication;
+
+class PinOne : public OutputControllerFlexCompleteBase
+{
+private:
+   std::mutex m_numberUpdateLocker;
+   int m_number = -1;
+
+   int m_minCommandIntervalMs = 1;
+   bool m_minCommandIntervalMsSet = false;
+
+   std::string m_comPort = "comm1";
+   bool m_comPortSet = false;
+   std::mutex m_portLocker;
+   PinOneCommunication* m_pinOneCommunication = nullptr;
+
+   std::vector<uint8_t> m_oldOutputValues;
+   std::chrono::steady_clock::time_point m_lastUpdate;
+
+   void UpdateDelay();
+
+public:
+   PinOne();
+   PinOne(const std::string& comPort);
+   virtual ~PinOne();
+
+   int GetNumber() const { return m_number; }
+   void SetNumber(int value);
+
+   int GetMinCommandIntervalMs() const { return m_minCommandIntervalMs; }
+   void SetMinCommandIntervalMs(int value);
+
+   const std::string& GetComPort() const { return m_comPort; }
+   void SetComPort(const std::string& value);
+
+   virtual void Init(Cabinet* cabinet) override;
+   virtual void Finish() override;
+
+   virtual std::string GetXmlElementName() const override { return "PinOne"; }
+   virtual tinyxml2::XMLElement* ToXml(tinyxml2::XMLDocument& doc) const override;
+   virtual bool FromXml(const tinyxml2::XMLElement* element) override;
+
+protected:
+   virtual bool VerifySettings() override;
+   virtual void UpdateOutputs(const std::vector<uint8_t>& newOutputValues) override;
+   virtual void ConnectToController() override;
+   virtual void DisconnectFromController() override;
+};
+
+}

--- a/src/cab/out/pinone/PinOneAutoConfigurator.cpp
+++ b/src/cab/out/pinone/PinOneAutoConfigurator.cpp
@@ -1,0 +1,156 @@
+#include "PinOneAutoConfigurator.h"
+#include "PinOne.h"
+#include "PinOneCommunication.h"
+#include "../../Cabinet.h"
+#include "../OutputControllerList.h"
+#include "../../../general/StringExtensions.h"
+#include "../../../Log.h"
+#include "../../toys/lwequivalent/LedWizEquivalent.h"
+#include "../../toys/ToyList.h"
+
+#include <libserialport.h>
+#include <algorithm>
+#include <thread>
+#include <chrono>
+
+namespace DOF
+{
+
+void PinOneAutoConfigurator::AutoConfig(Cabinet* cabinet)
+{
+   const int UnitBias = 10;
+
+   std::vector<std::string> preconfigured;
+   for (auto* controller : *cabinet->GetOutputControllers())
+   {
+      PinOne* pinOne = dynamic_cast<PinOne*>(controller);
+      if (pinOne)
+         preconfigured.push_back(pinOne->GetComPort());
+   }
+
+   std::string comPort = GetDevice();
+
+   if (std::find(preconfigured.begin(), preconfigured.end(), comPort) == preconfigured.end() && !comPort.empty())
+   {
+      PinOne* p = new PinOne(comPort);
+      if (!cabinet->GetOutputControllers()->Contains(p->GetName()))
+      {
+         cabinet->GetOutputControllers()->push_back(p);
+         Log::Write(StringExtensions::Build("Detected and added PinOne Controller Nr. {0} with name {1}", std::to_string(p->GetNumber()), p->GetName()));
+
+         bool foundEquivalent = false;
+         for (auto* toy : *cabinet->GetToys())
+         {
+            LedWizEquivalent* lwe = dynamic_cast<LedWizEquivalent*>(toy);
+            if (lwe && lwe->GetLedWizNumber() == p->GetNumber() + UnitBias)
+            {
+               foundEquivalent = true;
+               break;
+            }
+         }
+
+         if (!foundEquivalent)
+         {
+            LedWizEquivalent* lwe = new LedWizEquivalent();
+            lwe->SetLedWizNumber(p->GetNumber() + UnitBias);
+            lwe->SetName(StringExtensions::Build("{0} Equivalent", p->GetName()));
+
+            for (int i = 1; i <= p->GetNumberOfOutputs(); i++)
+            {
+               LedWizEquivalentOutput* lweo = new LedWizEquivalentOutput();
+               lweo->SetOutputName(StringExtensions::Build("{0}\\{0}.{1:00}", p->GetName(), std::to_string(i)));
+               lweo->SetLedWizEquivalentOutputNumber(i);
+               lwe->GetOutputs().AddOutput(lweo);
+            }
+
+            if (!cabinet->GetToys()->Contains(lwe->GetName()))
+            {
+               cabinet->GetToys()->push_back(lwe);
+               Log::Write(StringExtensions::Build("Added LedwizEquivalent Nr. {0} with name {1} for PinOne Controller Nr. {2}, {3}", std::to_string(lwe->GetLedWizNumber()), lwe->GetName(),
+                  std::to_string(p->GetNumber()), std::to_string(p->GetNumberOfOutputs())));
+            }
+         }
+      }
+   }
+}
+
+std::string PinOneAutoConfigurator::GetDevice()
+{
+   struct sp_port** portList;
+   if (sp_list_ports(&portList) != SP_OK)
+      return "";
+
+   for (int i = 0; portList[i] != nullptr; i++)
+   {
+      struct sp_port* port = nullptr;
+      char* portName = sp_get_port_name(portList[i]);
+
+      if (!portName)
+         continue;
+
+      try
+      {
+         if (sp_get_port_by_name(portName, &port) != SP_OK)
+            continue;
+
+         if (sp_open(port, SP_MODE_READ_WRITE) != SP_OK)
+         {
+            sp_free_port(port);
+            continue;
+         }
+
+         sp_set_baudrate(port, 2000000);
+         sp_set_bits(port, 8);
+         sp_set_parity(port, SP_PARITY_NONE);
+         sp_set_stopbits(port, 1);
+         sp_set_dtr(port, SP_DTR_ON);
+
+         std::this_thread::sleep_for(std::chrono::milliseconds(50));
+         sp_flush(port, SP_BUF_BOTH);
+         std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+         uint8_t command[] = { 0, 251, 0, 0, 0, 0, 0, 0, 0 };
+         sp_blocking_write(port, command, 9, 100);
+
+         char buffer[256];
+         int bytesRead = sp_blocking_read(port, buffer, sizeof(buffer) - 1, 100);
+
+         if (bytesRead > 0)
+         {
+            buffer[bytesRead] = '\0';
+            std::string result(buffer);
+            if (result == "DEBUG,CSD Board Connected")
+            {
+               sp_close(port);
+               sp_free_port(port);
+               sp_free_port_list(portList);
+               return std::string(portName);
+            }
+         }
+
+         sp_close(port);
+         sp_free_port(port);
+      }
+      catch (...)
+      {
+         if (port)
+         {
+            sp_close(port);
+            sp_free_port(port);
+         }
+      }
+   }
+
+   sp_free_port_list(portList);
+
+   std::string comPort = "";
+   PinOneCommunication communication("");
+   if (communication.ConnectToServer())
+   {
+      comPort = communication.GetCOMPort();
+   }
+
+   return comPort;
+}
+
+}

--- a/src/cab/out/pinone/PinOneAutoConfigurator.h
+++ b/src/cab/out/pinone/PinOneAutoConfigurator.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "../IAutoConfigOutputController.h"
+
+namespace DOF
+{
+
+class Cabinet;
+
+class PinOneAutoConfigurator : public IAutoConfigOutputController
+{
+public:
+   virtual void AutoConfig(Cabinet* cabinet) override;
+   static std::string GetDevice();
+};
+
+}

--- a/src/cab/out/pinone/PinOneCommunication.cpp
+++ b/src/cab/out/pinone/PinOneCommunication.cpp
@@ -1,0 +1,214 @@
+#include "PinOneCommunication.h"
+#include "NamedPipeServer.h"
+#include "../../../general/StringExtensions.h"
+#include <vector>
+#include <stdexcept>
+#include <thread>
+#include <chrono>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <fcntl.h>
+#endif
+
+namespace DOF
+{
+
+PinOneCommunication::PinOneCommunication(const std::string& comPort)
+   : m_comPort(comPort)
+{
+}
+
+PinOneCommunication::~PinOneCommunication()
+{
+   try
+   {
+      if (m_server)
+      {
+         m_server->StopServer();
+         delete m_server;
+         m_server = nullptr;
+      }
+   }
+   catch (...)
+   {
+   }
+}
+
+bool PinOneCommunication::ConnectToServer()
+{
+   try
+   {
+#ifdef _WIN32
+      std::string pipePath = "\\\\.\\pipe\\" + m_pipeName;
+      HANDLE pipe = CreateFileA(pipePath.c_str(), GENERIC_READ | GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, 0, nullptr);
+
+      if (pipe == INVALID_HANDLE_VALUE)
+         return false;
+
+      DWORD mode = PIPE_READMODE_BYTE;
+      if (!SetNamedPipeHandleState(pipe, &mode, nullptr, nullptr))
+      {
+         CloseHandle(pipe);
+         return false;
+      }
+
+      m_pipeClient = pipe;
+#else
+      int sockfd = socket(AF_UNIX, SOCK_STREAM, 0);
+      if (sockfd < 0)
+         return false;
+
+      struct sockaddr_un addr;
+      memset(&addr, 0, sizeof(addr));
+      addr.sun_family = AF_UNIX;
+      strncpy(addr.sun_path, ("/tmp/" + m_pipeName).c_str(), sizeof(addr.sun_path) - 1);
+
+      if (connect(sockfd, (struct sockaddr*)&addr, sizeof(addr)) < 0)
+      {
+         close(sockfd);
+         return false;
+      }
+
+      m_pipeClient = reinterpret_cast<void*>(static_cast<intptr_t>(sockfd));
+#endif
+      return true;
+   }
+   catch (...)
+   {
+      return false;
+   }
+}
+
+bool PinOneCommunication::DisconnectFromServer()
+{
+   Disconnect();
+   if (m_server)
+   {
+      m_server->StopServer();
+      delete m_server;
+      m_server = nullptr;
+      return true;
+   }
+   return false;
+}
+
+bool PinOneCommunication::CreateServer()
+{
+   try
+   {
+      if (!StringExtensions::IsNullOrEmpty(m_comPort))
+      {
+         m_server = new NamedPipeServer(m_comPort);
+         m_server->StartServer();
+         std::this_thread::sleep_for(std::chrono::milliseconds(300));
+         return true;
+      }
+   }
+   catch (...)
+   {
+      return false;
+   }
+   return false;
+}
+
+bool PinOneCommunication::IsComPortConnected()
+{
+   SendPipeMessage("CHECK");
+   std::string response = ReadMessage();
+   return response == "TRUE";
+}
+
+void PinOneCommunication::Disconnect() { SendPipeMessage("DISCONNECT"); }
+
+void PinOneCommunication::Write(const std::vector<uint8_t>& bytesToWrite)
+{
+   std::string base64Bytes = StringExtensions::ToBase64(bytesToWrite);
+   SendPipeMessage("WRITE " + base64Bytes);
+   ReadMessage();
+}
+
+std::string PinOneCommunication::ReadLine()
+{
+   SendPipeMessage("READLINE");
+   return ReadMessage();
+}
+
+std::string PinOneCommunication::GetCOMPort()
+{
+   SendPipeMessage("COMPORT");
+   return ReadMessage();
+}
+
+void PinOneCommunication::SendPipeMessage(const std::string& message)
+{
+   try
+   {
+#ifdef _WIN32
+      HANDLE pipe = static_cast<HANDLE>(m_pipeClient);
+      DWORD bytesWritten;
+      if (!WriteFile(pipe, message.c_str(), static_cast<DWORD>(message.length()), &bytesWritten, nullptr))
+      {
+         throw std::runtime_error("Failed to write to pipe");
+      }
+#else
+      int sockfd = static_cast<int>(reinterpret_cast<intptr_t>(m_pipeClient));
+      ssize_t result = write(sockfd, message.c_str(), message.length());
+      if (result < 0)
+         throw std::runtime_error("Failed to write to socket");
+#endif
+   }
+   catch (...)
+   {
+      if (CreateServer() && ConnectToServer())
+      {
+#ifdef _WIN32
+         HANDLE pipe = static_cast<HANDLE>(m_pipeClient);
+         DWORD bytesWritten;
+         WriteFile(pipe, message.c_str(), static_cast<DWORD>(message.length()), &bytesWritten, nullptr);
+#else
+         int sockfd = static_cast<int>(reinterpret_cast<intptr_t>(m_pipeClient));
+         write(sockfd, message.c_str(), message.length());
+#endif
+      }
+      else
+         throw std::runtime_error("Unable to connect to board");
+   }
+}
+
+std::string PinOneCommunication::ReadMessage()
+{
+   try
+   {
+      std::vector<char> response(1024);
+
+#ifdef _WIN32
+      HANDLE pipe = static_cast<HANDLE>(m_pipeClient);
+      DWORD bytesRead;
+      if (!ReadFile(pipe, response.data(), static_cast<DWORD>(response.size()), &bytesRead, nullptr))
+      {
+         throw std::runtime_error("Failed to read from pipe");
+      }
+      return std::string(response.data(), bytesRead);
+#else
+      int sockfd = static_cast<int>(reinterpret_cast<intptr_t>(m_pipeClient));
+      ssize_t bytesRead = read(sockfd, response.data(), response.size());
+      if (bytesRead < 0)
+         throw std::runtime_error("Failed to read from socket");
+      return std::string(response.data(), bytesRead);
+#endif
+   }
+   catch (...)
+   {
+      if (CreateServer() && ConnectToServer())
+         return ReadMessage();
+      else
+         return "";
+   }
+}
+
+}

--- a/src/cab/out/pinone/PinOneCommunication.h
+++ b/src/cab/out/pinone/PinOneCommunication.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <cstdint>
+
+namespace DOF
+{
+
+class NamedPipeServer;
+
+class PinOneCommunication
+{
+private:
+   void* m_pipeClient = nullptr;
+   NamedPipeServer* m_server = nullptr;
+   std::string m_pipeName = "ComPortServerPipe";
+   std::string m_comPort;
+
+
+public:
+   PinOneCommunication(const std::string& comPort);
+   ~PinOneCommunication();
+
+   bool ConnectToServer();
+   bool DisconnectFromServer();
+   bool CreateServer();
+   bool IsComPortConnected();
+   void Disconnect();
+   void Write(const std::vector<uint8_t>& bytesToWrite);
+   std::string ReadLine();
+   std::string GetCOMPort();
+
+private:
+   void SendPipeMessage(const std::string& message);
+   std::string ReadMessage();
+};
+
+}

--- a/src/cab/out/ps/Pinscape.cpp
+++ b/src/cab/out/ps/Pinscape.cpp
@@ -221,8 +221,13 @@ tinyxml2::XMLElement* Pinscape::ToXml(tinyxml2::XMLDocument& doc) const
 {
    tinyxml2::XMLElement* element = OutputControllerFlexCompleteBase::ToXml(doc);
 
-   element->SetAttribute("Number", m_number);
-   element->SetAttribute("MinCommandIntervalMs", m_minCommandIntervalMs);
+   tinyxml2::XMLElement* numberElement = doc.NewElement("Number");
+   numberElement->SetText(m_number);
+   element->InsertEndChild(numberElement);
+
+   tinyxml2::XMLElement* intervalElement = doc.NewElement("MinCommandIntervalMs");
+   intervalElement->SetText(m_minCommandIntervalMs);
+   element->InsertEndChild(intervalElement);
 
    return element;
 }
@@ -232,13 +237,32 @@ bool Pinscape::FromXml(const tinyxml2::XMLElement* element)
    if (!OutputControllerFlexCompleteBase::FromXml(element))
       return false;
 
-   int number = m_number;
-   element->QueryIntAttribute("Number", &number);
-   SetNumber(number);
+   const tinyxml2::XMLElement* numberElement = element->FirstChildElement("Number");
+   if (numberElement && numberElement->GetText())
+   {
+      try
+      {
+         int number = std::stoi(numberElement->GetText());
+         SetNumber(number);
+      }
+      catch (...)
+      {
+         return false;
+      }
+   }
 
-   int minInterval = m_minCommandIntervalMs;
-   element->QueryIntAttribute("MinCommandIntervalMs", &minInterval);
-   SetMinCommandIntervalMs(minInterval);
+   const tinyxml2::XMLElement* intervalElement = element->FirstChildElement("MinCommandIntervalMs");
+   if (intervalElement && intervalElement->GetText())
+   {
+      try
+      {
+         int interval = std::stoi(intervalElement->GetText());
+         SetMinCommandIntervalMs(interval);
+      }
+      catch (...)
+      {
+      }
+   }
 
    return true;
 }

--- a/src/cab/out/pspico/PinscapePicoAutoConfigurator.cpp
+++ b/src/cab/out/pspico/PinscapePicoAutoConfigurator.cpp
@@ -72,7 +72,7 @@ void PinscapePicoAutoConfigurator::AutoConfig(Cabinet* cabinet)
 
             if (!toyExists)
             {
-               auto lwe = new LedWizEquivalent();
+               LedWizEquivalent* lwe = new LedWizEquivalent();
                lwe->SetLedWizNumber(dofUnitNumber);
                lwe->SetName(StringExtensions::Build("{0} Equivalent", p->GetName()));
 

--- a/src/cab/schedules/ScheduledSetting.h
+++ b/src/cab/schedules/ScheduledSetting.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "ScheduledSettingDevice.h"
 #include "../../general/generic/IXmlSerializable.h"
 #include <string>
 #include <chrono>
@@ -13,31 +14,34 @@ public:
    ScheduledSetting();
    virtual ~ScheduledSetting() = default;
 
-   const std::string& GetConfigPostfixID() const { return m_configPostfixID; }
-   void SetConfigPostfixID(const std::string& value) { m_configPostfixID = value; }
+   const std::string& GetName() const { return m_name; }
+   void SetName(const std::string& value) { m_name = value; }
 
-   int GetOutputNumber() const { return m_outputNumber; }
-   void SetOutputNumber(int value) { m_outputNumber = value; }
+   bool IsEnabled() const { return m_enabled; }
+   void SetEnabled(bool value) { m_enabled = value; }
 
-   const std::string& GetTimeframe() const { return m_timeframe; }
-   void SetTimeframe(const std::string& value) { m_timeframe = value; }
+   const std::string& GetClockStart() const { return m_clockStart; }
+   void SetClockStart(const std::string& value) { m_clockStart = value; }
 
-   int GetOutputStrength() const { return m_outputStrength; }
-   void SetOutputStrength(int value);
+   const std::string& GetClockEnd() const { return m_clockEnd; }
+   void SetClockEnd(const std::string& value) { m_clockEnd = value; }
 
-   bool IsTimeframeActive() const;
-   bool IsTimeframeActive(const std::chrono::system_clock::time_point& now) const;
+   ScheduledSettingDeviceList& GetScheduledSettingDeviceList() { return m_scheduledSettingDeviceList; }
+   const ScheduledSettingDeviceList& GetScheduledSettingDeviceList() const { return m_scheduledSettingDeviceList; }
 
+   bool IsTimeInRange() const;
+   bool IsTimeInRange(const std::chrono::system_clock::time_point& now) const;
 
    virtual tinyxml2::XMLElement* ToXml(tinyxml2::XMLDocument& doc) const override;
    virtual bool FromXml(const tinyxml2::XMLElement* element) override;
    virtual std::string GetXmlElementName() const override { return "ScheduledSetting"; }
 
 private:
-   std::string m_configPostfixID;
-   int m_outputNumber;
-   std::string m_timeframe;
-   int m_outputStrength;
+   std::string m_name;
+   bool m_enabled;
+   std::string m_clockStart;
+   std::string m_clockEnd;
+   ScheduledSettingDeviceList m_scheduledSettingDeviceList;
 
    struct TimeRange
    {
@@ -48,7 +52,7 @@ private:
       bool crossesMidnight;
    };
 
-   TimeRange ParseTimeframe(const std::string& timeframe) const;
+   TimeRange ParseMilitaryTime(const std::string& clockStart, const std::string& clockEnd) const;
    bool IsTimeInRange(const TimeRange& range, int hour, int minute) const;
 };
 

--- a/src/cab/schedules/ScheduledSettingDevice.cpp
+++ b/src/cab/schedules/ScheduledSettingDevice.cpp
@@ -1,0 +1,161 @@
+#include "ScheduledSettingDevice.h"
+#include "../../general/StringExtensions.h"
+#include "../../general/MathExtensions.h"
+#include "../../Log.h"
+#include <tinyxml2/tinyxml2.h>
+#include <sstream>
+
+namespace DOF
+{
+
+ScheduledSettingDevice::ScheduledSettingDevice()
+   : m_name("")
+   , m_configPostfixID(0)
+   , m_outputs("")
+   , m_outputPercent(100)
+{
+}
+
+void ScheduledSettingDevice::SetOutputs(const std::string& value)
+{
+   m_outputs = value;
+   ParseOutputs();
+}
+
+void ScheduledSettingDevice::SetOutputPercent(int value) { m_outputPercent = MathExtensions::Limit(value, 0, 100); }
+
+void ScheduledSettingDevice::ParseOutputs()
+{
+   m_outputList.clear();
+
+   if (m_outputs.empty())
+      return;
+
+   std::vector<std::string> parts = StringExtensions::Split(m_outputs, { ',' });
+
+   for (const std::string& part : parts)
+   {
+      std::string trimmed = StringExtensions::Trim(part);
+      if (!trimmed.empty())
+      {
+         try
+         {
+            int outputNum = std::stoi(trimmed);
+            if (outputNum > 0)
+               m_outputList.push_back(outputNum);
+         }
+         catch (...)
+         {
+         }
+      }
+   }
+}
+
+tinyxml2::XMLElement* ScheduledSettingDevice::ToXml(tinyxml2::XMLDocument& doc) const
+{
+   tinyxml2::XMLElement* element = doc.NewElement(GetXmlElementName().c_str());
+
+   if (!m_name.empty())
+   {
+      tinyxml2::XMLElement* nameElement = doc.NewElement("Name");
+      nameElement->SetText(m_name.c_str());
+      element->InsertEndChild(nameElement);
+   }
+
+   tinyxml2::XMLElement* configElement = doc.NewElement("ConfigPostfixID");
+   configElement->SetText(m_configPostfixID);
+   element->InsertEndChild(configElement);
+
+   if (!m_outputs.empty())
+   {
+      tinyxml2::XMLElement* outputsElement = doc.NewElement("Outputs");
+      outputsElement->SetText(m_outputs.c_str());
+      element->InsertEndChild(outputsElement);
+   }
+
+   tinyxml2::XMLElement* percentElement = doc.NewElement("OutputPercent");
+   percentElement->SetText(m_outputPercent);
+   element->InsertEndChild(percentElement);
+
+   return element;
+}
+
+bool ScheduledSettingDevice::FromXml(const tinyxml2::XMLElement* element)
+{
+   if (!element)
+      return false;
+
+   const tinyxml2::XMLElement* nameElement = element->FirstChildElement("Name");
+   if (nameElement && nameElement->GetText())
+      m_name = nameElement->GetText();
+
+   const tinyxml2::XMLElement* configElement = element->FirstChildElement("ConfigPostfixID");
+   if (configElement)
+      configElement->QueryIntText(&m_configPostfixID);
+
+   const tinyxml2::XMLElement* outputsElement = element->FirstChildElement("Outputs");
+   if (outputsElement && outputsElement->GetText())
+      SetOutputs(outputsElement->GetText());
+
+   const tinyxml2::XMLElement* percentElement = element->FirstChildElement("OutputPercent");
+   if (percentElement)
+   {
+      int percent;
+      if (percentElement->QueryIntText(&percent) == tinyxml2::XML_SUCCESS)
+         SetOutputPercent(percent);
+   }
+
+   return true;
+}
+
+// ScheduledSettingDeviceList implementation
+
+ScheduledSettingDeviceList::ScheduledSettingDeviceList() { }
+
+ScheduledSettingDeviceList::~ScheduledSettingDeviceList() { Clear(); }
+
+void ScheduledSettingDeviceList::Clear()
+{
+   for (ScheduledSettingDevice* device : *this)
+      delete device;
+   clear();
+}
+
+tinyxml2::XMLElement* ScheduledSettingDeviceList::ToXml(tinyxml2::XMLDocument& doc) const
+{
+   tinyxml2::XMLElement* element = doc.NewElement(GetXmlElementName().c_str());
+
+   for (const ScheduledSettingDevice* device : *this)
+   {
+      if (device)
+      {
+         tinyxml2::XMLElement* deviceElement = device->ToXml(doc);
+         if (deviceElement)
+            element->InsertEndChild(deviceElement);
+      }
+   }
+
+   return element;
+}
+
+bool ScheduledSettingDeviceList::FromXml(const tinyxml2::XMLElement* element)
+{
+   if (!element)
+      return false;
+
+   Clear();
+
+   for (const tinyxml2::XMLElement* deviceElement = element->FirstChildElement("ScheduledSettingDevice"); deviceElement;
+      deviceElement = deviceElement->NextSiblingElement("ScheduledSettingDevice"))
+   {
+      ScheduledSettingDevice* device = new ScheduledSettingDevice();
+      if (device->FromXml(deviceElement))
+         push_back(device);
+      else
+         delete device;
+   }
+
+   return true;
+}
+
+}

--- a/src/cab/schedules/ScheduledSettingDevice.h
+++ b/src/cab/schedules/ScheduledSettingDevice.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "../../general/generic/IXmlSerializable.h"
+#include <string>
+#include <vector>
+
+namespace DOF
+{
+
+class ScheduledSettingDevice : public IXmlSerializable
+{
+public:
+   ScheduledSettingDevice();
+   virtual ~ScheduledSettingDevice() = default;
+
+   const std::string& GetName() const { return m_name; }
+   void SetName(const std::string& value) { m_name = value; }
+
+   int GetConfigPostfixID() const { return m_configPostfixID; }
+   void SetConfigPostfixID(int value) { m_configPostfixID = value; }
+
+   const std::string& GetOutputs() const { return m_outputs; }
+   void SetOutputs(const std::string& value);
+
+   const std::vector<int>& GetOutputList() const { return m_outputList; }
+
+   int GetOutputPercent() const { return m_outputPercent; }
+   void SetOutputPercent(int value);
+
+   virtual tinyxml2::XMLElement* ToXml(tinyxml2::XMLDocument& doc) const override;
+   virtual bool FromXml(const tinyxml2::XMLElement* element) override;
+   virtual std::string GetXmlElementName() const override { return "ScheduledSettingDevice"; }
+
+private:
+   std::string m_name;
+   int m_configPostfixID;
+   std::string m_outputs;
+   std::vector<int> m_outputList;
+   int m_outputPercent;
+
+   void ParseOutputs();
+};
+
+class ScheduledSettingDeviceList : public std::vector<ScheduledSettingDevice*>, public IXmlSerializable
+{
+public:
+   ScheduledSettingDeviceList();
+   virtual ~ScheduledSettingDeviceList();
+
+   virtual tinyxml2::XMLElement* ToXml(tinyxml2::XMLDocument& doc) const override;
+   virtual bool FromXml(const tinyxml2::XMLElement* element) override;
+   virtual std::string GetXmlElementName() const override { return "ScheduledSettingDeviceList"; }
+
+private:
+   void Clear();
+};
+
+}

--- a/src/cab/toys/hardware/LedStrip.cpp
+++ b/src/cab/toys/hardware/LedStrip.cpp
@@ -336,6 +336,13 @@ void LedStrip::SetOutputData()
          }
          break;
       }
+
+      if (m_brightness < 1.0f)
+      {
+         float correctedBrightness = std::pow(m_brightness, m_brightnessGammaCorrection);
+         for (auto& outputValue : m_outputData)
+            outputValue = static_cast<uint8_t>(outputValue * correctedBrightness);
+      }
    }
 }
 

--- a/src/fx/matrixfx/MatrixEffectBase.h
+++ b/src/fx/matrixfx/MatrixEffectBase.h
@@ -94,15 +94,15 @@ template <typename MatrixElementType> void MatrixEffectBase<MatrixElementType>::
 
 template <typename MatrixElementType> void MatrixEffectBase<MatrixElementType>::Init(Table* table)
 {
-   Log::Write(StringExtensions::Build("MatrixEffectBase::Init - Looking for toy '{0}'", m_toyName));
+   Log::Debug(StringExtensions::Build("MatrixEffectBase::Init - Looking for toy '{0}'", m_toyName));
    if (!StringExtensions::IsNullOrWhiteSpace(m_toyName) && table->GetPinball()->GetCabinet()->GetToys()->Contains(m_toyName))
    {
-      Log::Write(StringExtensions::Build("MatrixEffectBase::Init - Found toy '{0}'", m_toyName));
+      Log::Debug(StringExtensions::Build("MatrixEffectBase::Init - Found toy '{0}'", m_toyName));
       IToy* toy = table->GetPinball()->GetCabinet()->GetToys()->FindByName(m_toyName);
       IMatrixToy<MatrixElementType>* matrixToy = dynamic_cast<IMatrixToy<MatrixElementType>*>(toy);
       if (matrixToy != nullptr)
       {
-         Log::Write(StringExtensions::Build("MatrixEffectBase::Init - Successfully cast toy '{0}' to IMatrixToy, layer {1}", m_toyName, std::to_string(m_layerNr)));
+         Log::Debug(StringExtensions::Build("MatrixEffectBase::Init - Successfully cast toy '{0}' to IMatrixToy, layer {1}", m_toyName, std::to_string(m_layerNr)));
          m_matrix = matrixToy;
          m_matrixLayer = m_matrix->GetLayer(m_layerNr);
 
@@ -126,12 +126,12 @@ template <typename MatrixElementType> void MatrixEffectBase<MatrixElementType>::
       }
       else
       {
-         Log::Write(StringExtensions::Build("MatrixEffectBase::Init - Failed to cast toy '{0}' to IMatrixToy", m_toyName));
+         Log::Debug(StringExtensions::Build("MatrixEffectBase::Init - Failed to cast toy '{0}' to IMatrixToy", m_toyName));
       }
    }
    else
    {
-      Log::Write(StringExtensions::Build("MatrixEffectBase::Init - Toy '{0}' not found in cabinet", m_toyName));
+      Log::Debug(StringExtensions::Build("MatrixEffectBase::Init - Toy '{0}' not found in cabinet", m_toyName));
    }
 
    m_table = table;

--- a/src/general/StringExtensions.cpp
+++ b/src/general/StringExtensions.cpp
@@ -1,4 +1,5 @@
 #include "StringExtensions.h"
+#include <iomanip>
 
 namespace DOF
 {
@@ -245,6 +246,104 @@ int StringExtensions::HexToInt(const std::string& s)
    int result;
    std::istringstream iss(s);
    iss >> std::hex >> result;
+   return result;
+}
+
+std::string StringExtensions::FormatNumber(int value, int padding)
+{
+   std::ostringstream oss;
+   oss << std::setfill('0') << std::setw(padding) << value;
+   return oss.str();
+}
+
+std::string StringExtensions::ToBase64(const std::vector<uint8_t>& data)
+{
+   static const std::string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+   std::string result;
+   int i = 0;
+   unsigned char char_array_3[3];
+   unsigned char char_array_4[4];
+
+   for (auto byte : data)
+   {
+      char_array_3[i++] = byte;
+      if (i == 3)
+      {
+         char_array_4[0] = (char_array_3[0] & 0xfc) >> 2;
+         char_array_4[1] = ((char_array_3[0] & 0x03) << 4) + ((char_array_3[1] & 0xf0) >> 4);
+         char_array_4[2] = ((char_array_3[1] & 0x0f) << 2) + ((char_array_3[2] & 0xc0) >> 6);
+         char_array_4[3] = char_array_3[2] & 0x3f;
+
+         for (i = 0; i < 4; i++)
+            result += chars[char_array_4[i]];
+         i = 0;
+      }
+   }
+
+   if (i)
+   {
+      for (int j = i; j < 3; j++)
+         char_array_3[j] = '\0';
+
+      char_array_4[0] = (char_array_3[0] & 0xfc) >> 2;
+      char_array_4[1] = ((char_array_3[0] & 0x03) << 4) + ((char_array_3[1] & 0xf0) >> 4);
+      char_array_4[2] = ((char_array_3[1] & 0x0f) << 2) + ((char_array_3[2] & 0xc0) >> 6);
+      char_array_4[3] = char_array_3[2] & 0x3f;
+
+      for (int j = 0; j < i + 1; j++)
+         result += chars[char_array_4[j]];
+
+      while (i++ < 3)
+         result += '=';
+   }
+
+   return result;
+}
+
+std::vector<uint8_t> StringExtensions::FromBase64(const std::string& base64)
+{
+   static const std::string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+   std::vector<uint8_t> result;
+   int in_len = base64.length();
+   int i = 0;
+   int in = 0;
+   unsigned char char_array_4[4], char_array_3[3];
+
+   while (in_len-- && (base64[in] != '=') && (isalnum(base64[in]) || (base64[in] == '+') || (base64[in] == '/')))
+   {
+      char_array_4[i++] = base64[in];
+      in++;
+      if (i == 4)
+      {
+         for (i = 0; i < 4; i++)
+            char_array_4[i] = chars.find(char_array_4[i]);
+
+         char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
+         char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
+         char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
+
+         for (i = 0; i < 3; i++)
+            result.push_back(char_array_3[i]);
+         i = 0;
+      }
+   }
+
+   if (i)
+   {
+      for (int j = i; j < 4; j++)
+         char_array_4[j] = 0;
+
+      for (int j = 0; j < 4; j++)
+         char_array_4[j] = chars.find(char_array_4[j]);
+
+      char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
+      char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
+      char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
+
+      for (int j = 0; j < i - 1; j++)
+         result.push_back(char_array_3[j]);
+   }
+
    return result;
 }
 

--- a/src/general/StringExtensions.h
+++ b/src/general/StringExtensions.h
@@ -38,6 +38,9 @@ public:
    static bool TryParseInt(const std::string& str, int& value);
    static bool IsHexString(const std::string& s);
    static int HexToInt(const std::string& s);
+   static std::string FormatNumber(int value, int padding);
+   static std::string ToBase64(const std::vector<uint8_t>& data);
+   static std::vector<uint8_t> FromBase64(const std::string& base64);
 };
 
 }

--- a/src/globalconfiguration/GlobalConfig.cpp
+++ b/src/globalconfiguration/GlobalConfig.cpp
@@ -278,7 +278,6 @@ std::unordered_map<std::string, std::string> GlobalConfig::GetReplaceValuesDicti
    d.emplace("AssemblyDirectory", fi.Directory()->FullName());
    d.emplace("AssemblyDir", fi.Directory()->FullName());
 
-   // Add InstallDir and BinDir path resolution
    std::string installFolder = DirectOutputHandler::GetInstallFolder();
    if (!installFolder.empty())
    {

--- a/src/ledcontrol/setup/Configurator.cpp
+++ b/src/ledcontrol/setup/Configurator.cpp
@@ -314,53 +314,48 @@ void Configurator::SetupTable(
 
                   if (rgbaMatrixToy != nullptr)
                   {
-                     if (tcs->HasLayer())
+                     if (tcs->GetColorConfig() != nullptr)
                      {
-                        RGBAMatrixColorEffect* matrixEffect = new RGBAMatrixColorEffect();
-                        effectName = StringExtensions::Build(
-                           "Ledwiz {0:00} Column {1:00} Setting {2:00} RGBAMatrixColorEffect", std::to_string(ledWizNr), std::to_string(tcc->GetNumber()), std::to_string(settingNumber));
-                        matrixEffect->SetName(effectName);
-                        matrixEffect->SetToyName(toy->GetName());
-                        matrixEffect->SetLayerNr(tcs->GetLayer());
-
-                        if (tcs->GetColorConfig() != nullptr)
+                        if (tcs->HasLayer())
                         {
+                           RGBAMatrixColorEffect* matrixEffect = new RGBAMatrixColorEffect();
+                           effectName = StringExtensions::Build(
+                              "Ledwiz {0:00} Column {1:00} Setting {2:00} RGBAMatrixColorEffect", std::to_string(ledWizNr), std::to_string(tcc->GetNumber()), std::to_string(settingNumber));
+                           matrixEffect->SetName(effectName);
+                           matrixEffect->SetToyName(toy->GetName());
+                           matrixEffect->SetLayerNr(tcs->GetLayer());
+
                            ColorConfig* colorConfig = tcs->GetColorConfig();
                            matrixEffect->SetActiveColor(RGBAColor(colorConfig->GetRed(), colorConfig->GetGreen(), colorConfig->GetBlue(), colorConfig->GetAlpha()));
-                           Log::Write(StringExtensions::Build("Matrix effect color from config: R={0} G={1} B={2} A={3}", std::to_string(colorConfig->GetRed()),
+                           Log::Debug(StringExtensions::Build("Matrix effect color from config: R={0} G={1} B={2} A={3}", std::to_string(colorConfig->GetRed()),
                               std::to_string(colorConfig->GetGreen()), std::to_string(colorConfig->GetBlue()), std::to_string(colorConfig->GetAlpha())));
+
+                           matrixEffect->SetInactiveColor(RGBAColor(0, 0, 0, 0));
+                           matrixEffect->SetFadeMode(tcs->GetBlink() > 0 ? FadeModeEnum::OnOff : FadeModeEnum::Fade);
+
+                           effect = static_cast<EffectBase*>(matrixEffect);
                         }
                         else
                         {
-                           matrixEffect->SetActiveColor(RGBAColor(255, 0, 0, 255)); // Set to Red for testing
-                           Log::Write("Matrix effect color: Using default Red (255,0,0,255)");
+                           RGBAColorEffect* rgbaEffect = new RGBAColorEffect();
+                           effectName = StringExtensions::Build(
+                              "Ledwiz {0:00} Column {1:00} Setting {2:00} RGBAColorEffect", std::to_string(ledWizNr), std::to_string(tcc->GetNumber()), std::to_string(settingNumber));
+                           rgbaEffect->SetName(effectName);
+                           rgbaEffect->SetToyName(toy->GetName());
+
+                           ColorConfig* colorConfig = tcs->GetColorConfig();
+                           rgbaEffect->SetActiveColor(RGBAColor(colorConfig->GetRed(), colorConfig->GetGreen(), colorConfig->GetBlue(), colorConfig->GetAlpha()));
+                           rgbaEffect->SetInactiveColor(RGBAColor(0, 0, 0, 0));
+                           rgbaEffect->SetFadeMode(tcs->GetBlink() > 0 ? FadeModeEnum::OnOff : FadeModeEnum::Fade);
+
+                           effect = rgbaEffect;
                         }
-
-                        matrixEffect->SetInactiveColor(RGBAColor(0, 0, 0, 0));
-                        matrixEffect->SetFadeMode(tcs->GetBlink() > 0 ? FadeModeEnum::OnOff : FadeModeEnum::Fade);
-
-                        effect = static_cast<EffectBase*>(matrixEffect);
                      }
                      else
                      {
-                        RGBAColorEffect* rgbaEffect = new RGBAColorEffect();
-                        effectName = StringExtensions::Build(
-                           "Ledwiz {0:00} Column {1:00} Setting {2:00} RGBAColorEffect", std::to_string(ledWizNr), std::to_string(tcc->GetNumber()), std::to_string(settingNumber));
-                        rgbaEffect->SetName(effectName);
-                        rgbaEffect->SetToyName(toy->GetName());
-
-                        if (tcs->GetColorConfig() != nullptr)
-                        {
-                           ColorConfig* colorConfig = tcs->GetColorConfig();
-                           rgbaEffect->SetActiveColor(RGBAColor(colorConfig->GetRed(), colorConfig->GetGreen(), colorConfig->GetBlue(), colorConfig->GetAlpha()));
-                        }
-                        else
-                           rgbaEffect->SetActiveColor(RGBAColor(255, 255, 255, 255));
-
-                        rgbaEffect->SetInactiveColor(RGBAColor(0, 0, 0, 0));
-                        rgbaEffect->SetFadeMode(tcs->GetBlink() > 0 ? FadeModeEnum::OnOff : FadeModeEnum::Fade);
-
-                        effect = rgbaEffect;
+                        Log::Warning(StringExtensions::Build("No color valid color definition found for area effect. Skipped setting {0} in column {1} for LedWizEqivalent number {2}",
+                           std::to_string(settingNumber), std::to_string(tcc->GetNumber()), std::to_string(ledWizNr)));
+                        continue;
                      }
                   }
                   else if (analogMatrixToy != nullptr)
@@ -389,7 +384,7 @@ void Configurator::SetupTable(
                   }
                   else if (rgbaToy != nullptr)
                   {
-                     if (tcs->HasLayer())
+                     if (tcs->GetColorConfig() != nullptr)
                      {
                         RGBAColorEffect* rgbaEffect = new RGBAColorEffect();
                         effectName = StringExtensions::Build(
@@ -397,14 +392,8 @@ void Configurator::SetupTable(
                         rgbaEffect->SetName(effectName);
                         rgbaEffect->SetToyName(toy->GetName());
 
-                        if (tcs->GetColorConfig() != nullptr)
-                        {
-                           ColorConfig* colorConfig = tcs->GetColorConfig();
-                           rgbaEffect->SetActiveColor(RGBAColor(colorConfig->GetRed(), colorConfig->GetGreen(), colorConfig->GetBlue(), colorConfig->GetAlpha()));
-                        }
-                        else
-                           rgbaEffect->SetActiveColor(RGBAColor(255, 255, 255, 255));
-
+                        ColorConfig* colorConfig = tcs->GetColorConfig();
+                        rgbaEffect->SetActiveColor(RGBAColor(colorConfig->GetRed(), colorConfig->GetGreen(), colorConfig->GetBlue(), colorConfig->GetAlpha()));
                         rgbaEffect->SetInactiveColor(RGBAColor(0, 0, 0, 0));
                         rgbaEffect->SetFadeMode(tcs->GetBlink() > 0 ? FadeModeEnum::OnOff : FadeModeEnum::Fade);
 
@@ -412,24 +401,9 @@ void Configurator::SetupTable(
                      }
                      else
                      {
-                        RGBAColorEffect* rgbaEffect = new RGBAColorEffect();
-                        effectName = StringExtensions::Build(
-                           "Ledwiz {0:00} Column {1:00} Setting {2:00} RGBAColorEffect", std::to_string(ledWizNr), std::to_string(tcc->GetNumber()), std::to_string(settingNumber));
-                        rgbaEffect->SetName(effectName);
-                        rgbaEffect->SetToyName(toy->GetName());
-
-                        if (tcs->GetColorConfig() != nullptr)
-                        {
-                           ColorConfig* colorConfig = tcs->GetColorConfig();
-                           rgbaEffect->SetActiveColor(RGBAColor(colorConfig->GetRed(), colorConfig->GetGreen(), colorConfig->GetBlue(), colorConfig->GetAlpha()));
-                        }
-                        else
-                           rgbaEffect->SetActiveColor(RGBAColor(255, 255, 255, 255));
-
-                        rgbaEffect->SetInactiveColor(RGBAColor(0, 0, 0, 0));
-                        rgbaEffect->SetFadeMode(tcs->GetBlink() > 0 ? FadeModeEnum::OnOff : FadeModeEnum::Fade);
-
-                        effect = rgbaEffect;
+                        Log::Warning(StringExtensions::Build("Skipped setting {0} in column {1} for LedWizEqivalent number {2} since it does not contain a color specification.",
+                           std::to_string(settingNumber), std::to_string(tcc->GetNumber()), std::to_string(ledWizNr)));
+                        continue;
                      }
                   }
                   else if (analogToy != nullptr)
@@ -445,7 +419,6 @@ void Configurator::SetupTable(
 
                   if (effect != nullptr)
                   {
-                     // 1. Add base effect immediately (matching C# pattern)
                      effect->SetName(StringExtensions::Build("Ledwiz {0:00} Column {1:00} Setting {2:00} " + effect->GetXmlElementName(), std::to_string(ledWizNr),
                         std::to_string(tcc->GetNumber()), std::to_string(settingNumber)));
                      MakeEffectNameUnique(effect, table);
@@ -453,7 +426,6 @@ void Configurator::SetupTable(
 
                      IEffect* finalEffect = effect;
 
-                     // 2. FadeEffect (if fading durations are set)
                      if (tcs->GetFadingUpDurationMs() > 0 || tcs->GetFadingDownDurationMs() > 0)
                      {
                         FadeEffect* fadeEffect = new FadeEffect();
@@ -468,7 +440,6 @@ void Configurator::SetupTable(
                         finalEffect = fadeEffect;
                      }
 
-                     // 3. BlinkEffect (if blink is enabled)
                      if (tcs->GetBlink())
                      {
                         BlinkEffect* blinkEffect = new BlinkEffect();
@@ -488,7 +459,6 @@ void Configurator::SetupTable(
                         finalEffect = blinkEffect;
                      }
 
-                     // 4. DurationEffect (if duration or positive blink count is set)
                      if (tcs->GetDurationMs() > 0 || tcs->GetBlink() > 0)
                      {
                         DurationEffect* durationEffect = new DurationEffect();
@@ -497,7 +467,6 @@ void Configurator::SetupTable(
                         durationEffect->SetName(durationName);
                         durationEffect->SetTargetEffectName(finalEffect->GetName());
 
-                        // Calculate duration like C# version
                         int duration;
                         if (tcs->GetDurationMs() > 0)
                         {
@@ -519,7 +488,6 @@ void Configurator::SetupTable(
                         finalEffect = durationEffect;
                      }
 
-                     // 5. DelayEffect (if wait duration is set)
                      if (tcs->GetWaitDurationMs() > 0)
                      {
                         DelayEffect* delayEffect = new DelayEffect();
@@ -533,7 +501,6 @@ void Configurator::SetupTable(
                         finalEffect = delayEffect;
                      }
 
-                     // 6. ValueInvertEffect (if invert is enabled)
                      if (tcs->GetInvert())
                      {
                         ValueInvertEffect* invertEffect = new ValueInvertEffect();
@@ -546,7 +513,6 @@ void Configurator::SetupTable(
                         finalEffect = invertEffect;
                      }
 
-                     // 7. ValueMapFullRangeEffect (if NoBool is false)
                      if (!tcs->GetNoBool())
                      {
                         ValueMapFullRangeEffect* fullRangeEffect = new ValueMapFullRangeEffect();
@@ -559,21 +525,16 @@ void Configurator::SetupTable(
                         finalEffect = fullRangeEffect;
                      }
 
-                     // Assign effect to table elements based on output control
                      switch (tcs->GetOutputControl())
                      {
                      case OutputControlEnum::FixedOn:
-                        // For fixed on effects, this would go to assigned static effects in full implementation
-                        // For now, create a synthetic descriptor as fallback
-                        {
-                           std::vector<std::string> tableElementDescriptors;
-                           tableElementDescriptors.push_back(
-                              StringExtensions::Build("{0}.{1}.{2}", std::to_string(ledWizNr), std::to_string(tcc->GetNumber()), std::to_string(settingNumber)));
-                           AssignEffectToTableElements(table, tableElementDescriptors, finalEffect);
-                        }
-                        break;
+                     {
+                        std::vector<std::string> tableElementDescriptors;
+                        tableElementDescriptors.push_back(StringExtensions::Build("{0}.{1}.{2}", std::to_string(ledWizNr), std::to_string(tcc->GetNumber()), std::to_string(settingNumber)));
+                        AssignEffectToTableElements(table, tableElementDescriptors, finalEffect);
+                     }
+                     break;
                      case OutputControlEnum::Controlled:
-                        // Use the actual table element from the setting (e.g., "L88")
                         if (!StringExtensions::IsNullOrWhiteSpace(tcs->GetTableElement()))
                         {
                            std::vector<std::string> tableElements = StringExtensions::Split(tcs->GetTableElement(), { '|' });
@@ -590,7 +551,6 @@ void Configurator::SetupTable(
                         }
                         else
                         {
-                           // Fallback to synthetic descriptor if no table element specified
                            std::vector<std::string> tableElementDescriptors;
                            tableElementDescriptors.push_back(
                               StringExtensions::Build("{0}.{1}.{2}", std::to_string(ledWizNr), std::to_string(tcc->GetNumber()), std::to_string(settingNumber)));
@@ -598,19 +558,14 @@ void Configurator::SetupTable(
                         }
                         break;
                      case OutputControlEnum::Condition:
-                        // For condition effects, this would use condition parsing in full implementation
-                        // For now, create a synthetic descriptor as fallback
-                        {
-                           std::vector<std::string> tableElementDescriptors;
-                           tableElementDescriptors.push_back(
-                              StringExtensions::Build("{0}.{1}.{2}", std::to_string(ledWizNr), std::to_string(tcc->GetNumber()), std::to_string(settingNumber)));
-                           AssignEffectToTableElements(table, tableElementDescriptors, finalEffect);
-                        }
-                        break;
+                     {
+                        std::vector<std::string> tableElementDescriptors;
+                        tableElementDescriptors.push_back(StringExtensions::Build("{0}.{1}.{2}", std::to_string(ledWizNr), std::to_string(tcc->GetNumber()), std::to_string(settingNumber)));
+                        AssignEffectToTableElements(table, tableElementDescriptors, finalEffect);
+                     }
+                     break;
                      case OutputControlEnum::FixedOff:
-                     default:
-                        // Don't assign fixed off effects
-                        break;
+                     default: break;
                      }
                   }
                }

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -73,7 +73,7 @@ void RunDOFTests(DOF::DOF* pDof)
 {
    Log("=== DOF Protocol Test Scenarios ===");
 
-   Log("1. L88 lamp test - 5 seconds on (watch PinscapePico LEDs)");
+   Log("1. L88 lamp test - 5 seconds on");
    pDof->DataReceive('L', 88, 1);
    std::this_thread::sleep_for(std::chrono::milliseconds(5000));
    Log("   L88 off - 2 seconds off");
@@ -99,7 +99,6 @@ void RunL88Tests(DOF::DOF* pDof)
 {
    Log("=== L88 Test Scenarios ===");
 
-   // Test 1: Basic on/off
    Log("1. Basic L88 on/off test");
    Log("   L88 1 (should fade up + start blinking)...");
    pDof->DataReceive('L', 88, 1);
@@ -109,7 +108,6 @@ void RunL88Tests(DOF::DOF* pDof)
    pDof->DataReceive('L', 88, 0);
    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
 
-   // Test 2: Rapid toggling
    Log("2. Rapid toggle test");
    for (int i = 0; i < 3; i++)
    {
@@ -122,7 +120,6 @@ void RunL88Tests(DOF::DOF* pDof)
       std::this_thread::sleep_for(std::chrono::milliseconds(300));
    }
 
-   // Test 3: Direct 255 vs 1 value
    Log("3. Value comparison test");
    Log("   L88 1 (should convert to 255)...");
    pDof->DataReceive('L', 88, 1);


### PR DESCRIPTION
This PR has a bunch of little fixes for properly supporting `AutoConfig` and enabling getting PinOne devices ready for testing.  The main two fixes are finally getting communication to Wemos D1 mini pro "Adressable" Led Strips, and properly supporting `Brightness` 0-100.

FWIW, Wemos are finicky on connection using libserial port, (data must be flushed), but I'm also powering my led strip directly from the board, so I need to have the brightness way down. Hopefully it works better with @arnoz26 PinMos - https://shop.arnoz.com/en/adressable-led/2-pinmos.html