### PR TITLE
libftdi: fix rpath for macos and linux

### DIFF
--- a/platforms/linux/aarch64/external.sh
+++ b/platforms/linux/aarch64/external.sh
@@ -80,7 +80,8 @@ cmake \
    -DSTATICLIBS=OFF \
    -DLIBUSB_INCLUDE_DIR=../libusb/libusb \
    -DLIBUSB_LIBRARIES=$(pwd)/../libusb/libusb/.libs/libusb-1.0.so \
-   -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+   -DCMAKE_INSTALL_RPATH='$$ORIGIN' \
+   -DCMAKE_BUILD_WITH_INSTALL_RPATH=TRUE \
    -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
    -B build
 cmake --build build -- -j${NUM_PROCS}

--- a/platforms/linux/x64/external.sh
+++ b/platforms/linux/x64/external.sh
@@ -80,7 +80,8 @@ cmake \
    -DSTATICLIBS=OFF \
    -DLIBUSB_INCLUDE_DIR=../libusb/libusb \
    -DLIBUSB_LIBRARIES=$(pwd)/../libusb/libusb/.libs/libusb-1.0.so \
-   -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+   -DCMAKE_INSTALL_RPATH='$$ORIGIN' \
+   -DCMAKE_BUILD_WITH_INSTALL_RPATH=TRUE \
    -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
    -B build
 cmake --build build -- -j${NUM_PROCS}

--- a/platforms/macos/arm64/external.sh
+++ b/platforms/macos/arm64/external.sh
@@ -77,15 +77,17 @@ curl -sL "http://developer.intra2net.com/git/?p=libftdi;a=snapshot;h=${LIBFTDI_S
 tar xzf libftdi-${LIBFTDI_SHA}.tar.gz
 mv libftdi-${LIBFTDI_SHA:0:7} libftdi
 cd libftdi
+sed -i.bak 's/cmake_minimum_required(VERSION 2.6 FATAL_ERROR)/cmake_minimum_required(VERSION 3.10)\ncmake_policy(SET CMP0042 NEW)/' CMakeLists.txt
 cmake \
    -DFTDI_EEPROM=OFF \
    -DEXAMPLES=OFF \
    -DSTATICLIBS=OFF \
    -DLIBUSB_INCLUDE_DIR=../libusb/libusb \
    -DLIBUSB_LIBRARIES=$(pwd)/../libusb/libusb/.libs/libusb-1.0.dylib \
-   -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
    -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 \
    -DCMAKE_OSX_ARCHITECTURES=arm64 \
+   -DCMAKE_INSTALL_NAME_DIR=@rpath \
+   -DCMAKE_INSTALL_RPATH=@loader_path \
    -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
    -B build
 cmake --build build -- -j${NUM_PROCS}

--- a/platforms/macos/x64/external.sh
+++ b/platforms/macos/x64/external.sh
@@ -77,6 +77,7 @@ curl -sL "http://developer.intra2net.com/git/?p=libftdi;a=snapshot;h=${LIBFTDI_S
 tar xzf libftdi-${LIBFTDI_SHA}.tar.gz
 mv libftdi-${LIBFTDI_SHA:0:7} libftdi
 cd libftdi
+sed -i.bak 's/cmake_minimum_required(VERSION 2.6 FATAL_ERROR)/cmake_minimum_required(VERSION 3.10)\ncmake_policy(SET CMP0042 NEW)/' CMakeLists.txt
 cmake \
    -DFTDI_EEPROM=OFF \
    -DEXAMPLES=OFF \
@@ -85,7 +86,8 @@ cmake \
    -DLIBUSB_LIBRARIES=$(pwd)/../libusb/libusb/.libs/libusb-1.0.dylib \
    -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 \
    -DCMAKE_OSX_ARCHITECTURES=x86_64 \
-   -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+   -DCMAKE_INSTALL_NAME_DIR=@rpath \
+   -DCMAKE_INSTALL_RPATH=@loader_path \
    -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
    -B build
 cmake --build build -- -j${NUM_PROCS}

--- a/platforms/win/x64/external.sh
+++ b/platforms/win/x64/external.sh
@@ -85,12 +85,12 @@ curl -sL "http://developer.intra2net.com/git/?p=libftdi;a=snapshot;h=${LIBFTDI_S
 tar xzf libftdi-${LIBFTDI_SHA}.tar.gz
 mv libftdi-${LIBFTDI_SHA:0:7} libftdi
 cd libftdi
+sed -i.bak 's/cmake_minimum_required([^)]*)/cmake_minimum_required(VERSION 3.10)/' CMakeLists.txt
 sed -i.bak 's/set_target_properties(ftdi1 PROPERTIES VERSION ${VERSION_FIXUP}\.${MINOR_VERSION}\.0 SOVERSION 2)/set_target_properties(ftdi1 PROPERTIES OUTPUT_NAME "ftdi164" VERSION ${VERSION_FIXUP}.${MINOR_VERSION}.0 SOVERSION 2)/' src/CMakeLists.txt
 CURRENT_DIR="$(pwd)"
 "${MSYS2_PATH}/usr/bin/bash.exe" -l -c "
    cd \"${CURRENT_DIR}\" &&
    cmake \
-      -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
       -DFTDI_EEPROM=OFF \
       -DEXAMPLES=OFF \
       -DSTATICLIBS=OFF \

--- a/platforms/win/x86/external.sh
+++ b/platforms/win/x86/external.sh
@@ -82,11 +82,11 @@ curl -sL "http://developer.intra2net.com/git/?p=libftdi;a=snapshot;h=${LIBFTDI_S
 tar xzf libftdi-${LIBFTDI_SHA}.tar.gz
 mv libftdi-${LIBFTDI_SHA:0:7} libftdi
 cd libftdi
+sed -i.bak 's/cmake_minimum_required([^)]*)/cmake_minimum_required(VERSION 3.10)/' CMakeLists.txt
 CURRENT_DIR="$(pwd)"
 MSYSTEM=MINGW32 "${MSYS2_PATH}/usr/bin/bash.exe" -l -c "
    cd \"${CURRENT_DIR}\" &&
    cmake \
-      -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
       -DFTDI_EEPROM=OFF \
       -DEXAMPLES=OFF \
       -DSTATICLIBS=OFF \


### PR DESCRIPTION
Before:

```
otool -L /Users/jmillard/Downloads/libdof-0.2.3-macos-arm64/libdof.0.2.3.dylib
/Users/jmillard/Downloads/libdof-0.2.3-macos-arm64/libdof.0.2.3.dylib:
	@rpath/libdof.0.2.3.dylib (compatibility version 0.0.0, current version 0.2.3)
	@rpath/libserialport.dylib (compatibility version 2.0.0, current version 2.1.0)
	@rpath/libhidapi.0.dylib (compatibility version 0.0.0, current version 0.15.0)
	/Users/runner/work/libdof/libdof/external/libftdi/build/src/libftdi1.2.dylib (compatibility version 2.0.0, current version 2.5.0)
	@rpath/libusb-1.0.dylib (compatibility version 6.0.0, current version 6.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1700.255.5)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1345.120.2)```
```

After:

```
otool -L /Users/jmillard/Downloads/libdof-0.2.3-macos-arm64/libdof.0.2.3.dylib
/Users/jmillard/Downloads/libdof-0.2.3-macos-arm64/libdof.0.2.3.dylib:
	@rpath/libdof.0.2.3.dylib (compatibility version 0.0.0, current version 0.2.3)
	@rpath/libserialport.dylib (compatibility version 2.0.0, current version 2.1.0)
	@rpath/libhidapi.0.dylib (compatibility version 0.0.0, current version 0.15.0)
	@rpath/libftdi1.2.dylib (compatibility version 2.0.0, current version 2.5.0)
	@rpath/libusb-1.0.dylib (compatibility version 6.0.0, current version 6.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1700.255.5)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1345.120.2)
```

