### PR TITLE
libftdi: switch to mirror as developer.intra2net.com http is down

### DIFF
--- a/platforms/linux/aarch64/external.sh
+++ b/platforms/linux/aarch64/external.sh
@@ -71,9 +71,9 @@ cd ..
 # build libftdi and copy to third-party
 #
 
-curl -sL "http://developer.intra2net.com/git/?p=libftdi;a=snapshot;h=${LIBFTDI_SHA};sf=tgz" -o libftdi-${LIBFTDI_SHA}.tar.gz
+curl -sL https://github.com/jsm174/libftdi/archive/${LIBFTDI_SHA}.tar.gz -o libftdi-${LIBFTDI_SHA}.tar.gz
 tar xzf libftdi-${LIBFTDI_SHA}.tar.gz
-mv libftdi-${LIBFTDI_SHA:0:7} libftdi
+mv libftdi-${LIBFTDI_SHA} libftdi
 cd libftdi
 sed -i.bak 's/cmake_minimum_required([^)]*)/cmake_minimum_required(VERSION 3.10)/' CMakeLists.txt
 cmake \

--- a/platforms/linux/x64/external.sh
+++ b/platforms/linux/x64/external.sh
@@ -71,9 +71,9 @@ cd ..
 # build libftdi and copy to third-party
 #
 
-curl -sL "http://developer.intra2net.com/git/?p=libftdi;a=snapshot;h=${LIBFTDI_SHA};sf=tgz" -o libftdi-${LIBFTDI_SHA}.tar.gz
+curl -sL https://github.com/jsm174/libftdi/archive/${LIBFTDI_SHA}.tar.gz -o libftdi-${LIBFTDI_SHA}.tar.gz
 tar xzf libftdi-${LIBFTDI_SHA}.tar.gz
-mv libftdi-${LIBFTDI_SHA:0:7} libftdi
+mv libftdi-${LIBFTDI_SHA} libftdi
 cd libftdi
 sed -i.bak 's/cmake_minimum_required([^)]*)/cmake_minimum_required(VERSION 3.10)/' CMakeLists.txt
 cmake \

--- a/platforms/macos/arm64/external.sh
+++ b/platforms/macos/arm64/external.sh
@@ -61,7 +61,7 @@ tar xzf hidapi-${HIDAPI_SHA}.tar.gz
 mv hidapi-${HIDAPI_SHA} hidapi
 cd hidapi
 cmake \
-   -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 \
+   -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 \
    -DCMAKE_OSX_ARCHITECTURES=arm64 \
    -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
    -B build
@@ -74,9 +74,9 @@ cd ..
 # build libftdi and copy to third-party
 #
 
-curl -sL "http://developer.intra2net.com/git/?p=libftdi;a=snapshot;h=${LIBFTDI_SHA};sf=tgz" -o libftdi-${LIBFTDI_SHA}.tar.gz
+curl -sL https://github.com/jsm174/libftdi/archive/${LIBFTDI_SHA}.tar.gz -o libftdi-${LIBFTDI_SHA}.tar.gz
 tar xzf libftdi-${LIBFTDI_SHA}.tar.gz
-mv libftdi-${LIBFTDI_SHA:0:7} libftdi
+mv libftdi-${LIBFTDI_SHA} libftdi
 cd libftdi
 sed -i.bak 's/cmake_minimum_required(VERSION 2.6 FATAL_ERROR)/cmake_minimum_required(VERSION 3.10)\ncmake_policy(SET CMP0042 NEW)/' CMakeLists.txt
 cmake \
@@ -85,7 +85,7 @@ cmake \
    -DSTATICLIBS=OFF \
    -DLIBUSB_INCLUDE_DIR=../libusb/libusb \
    -DLIBUSB_LIBRARIES=$(pwd)/../libusb/libusb/.libs/libusb-1.0.dylib \
-   -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 \
+   -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 \
    -DCMAKE_OSX_ARCHITECTURES=arm64 \
    -DCMAKE_INSTALL_NAME_DIR=@rpath \
    -DCMAKE_INSTALL_RPATH=@loader_path \

--- a/platforms/macos/x64/external.sh
+++ b/platforms/macos/x64/external.sh
@@ -61,7 +61,7 @@ tar xzf hidapi-${HIDAPI_SHA}.tar.gz
 mv hidapi-${HIDAPI_SHA} hidapi
 cd hidapi
 cmake \
-   -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 \
+   -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 \
    -DCMAKE_OSX_ARCHITECTURES=x86_64 \
    -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
    -B build
@@ -74,9 +74,9 @@ cd ..
 # build libftdi and copy to third-party
 #
 
-curl -sL "http://developer.intra2net.com/git/?p=libftdi;a=snapshot;h=${LIBFTDI_SHA};sf=tgz" -o libftdi-${LIBFTDI_SHA}.tar.gz
+curl -sL https://github.com/jsm174/libftdi/archive/${LIBFTDI_SHA}.tar.gz -o libftdi-${LIBFTDI_SHA}.tar.gz
 tar xzf libftdi-${LIBFTDI_SHA}.tar.gz
-mv libftdi-${LIBFTDI_SHA:0:7} libftdi
+mv libftdi-${LIBFTDI_SHA} libftdi
 cd libftdi
 sed -i.bak 's/cmake_minimum_required(VERSION 2.6 FATAL_ERROR)/cmake_minimum_required(VERSION 3.10)\ncmake_policy(SET CMP0042 NEW)/' CMakeLists.txt
 cmake \
@@ -85,7 +85,7 @@ cmake \
    -DSTATICLIBS=OFF \
    -DLIBUSB_INCLUDE_DIR=../libusb/libusb \
    -DLIBUSB_LIBRARIES=$(pwd)/../libusb/libusb/.libs/libusb-1.0.dylib \
-   -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 \
+   -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 \
    -DCMAKE_OSX_ARCHITECTURES=x86_64 \
    -DCMAKE_INSTALL_NAME_DIR=@rpath \
    -DCMAKE_INSTALL_RPATH=@loader_path \

--- a/platforms/win/x64/external.sh
+++ b/platforms/win/x64/external.sh
@@ -82,9 +82,9 @@ cd ..
 # build libftdi and copy to third-party
 #
 
-curl -sL "http://developer.intra2net.com/git/?p=libftdi;a=snapshot;h=${LIBFTDI_SHA};sf=tgz" -o libftdi-${LIBFTDI_SHA}.tar.gz
+curl -sL https://github.com/jsm174/libftdi/archive/${LIBFTDI_SHA}.tar.gz -o libftdi-${LIBFTDI_SHA}.tar.gz
 tar xzf libftdi-${LIBFTDI_SHA}.tar.gz
-mv libftdi-${LIBFTDI_SHA:0:7} libftdi
+mv libftdi-${LIBFTDI_SHA} libftdi
 cd libftdi
 sed -i.bak 's/cmake_minimum_required([^)]*)/cmake_minimum_required(VERSION 3.10)/' CMakeLists.txt
 sed -i.bak 's/set_target_properties(ftdi1 PROPERTIES VERSION ${VERSION_FIXUP}\.${MINOR_VERSION}\.0 SOVERSION 2)/set_target_properties(ftdi1 PROPERTIES OUTPUT_NAME "ftdi164" VERSION ${VERSION_FIXUP}.${MINOR_VERSION}.0 SOVERSION 2)/' src/CMakeLists.txt

--- a/platforms/win/x86/external.sh
+++ b/platforms/win/x86/external.sh
@@ -79,9 +79,9 @@ cd ..
 # build libftdi and copy to third-party
 #
 
-curl -sL "http://developer.intra2net.com/git/?p=libftdi;a=snapshot;h=${LIBFTDI_SHA};sf=tgz" -o libftdi-${LIBFTDI_SHA}.tar.gz
+curl -sL https://github.com/jsm174/libftdi/archive/${LIBFTDI_SHA}.tar.gz -o libftdi-${LIBFTDI_SHA}.tar.gz
 tar xzf libftdi-${LIBFTDI_SHA}.tar.gz
-mv libftdi-${LIBFTDI_SHA:0:7} libftdi
+mv libftdi-${LIBFTDI_SHA} libftdi
 cd libftdi
 sed -i.bak 's/cmake_minimum_required([^)]*)/cmake_minimum_required(VERSION 3.10)/' CMakeLists.txt
 CURRENT_DIR="$(pwd)"


### PR DESCRIPTION
`http://developer.intra2net.com/git/?p=libftdi;a=snapshot;h=${LIBFTDI_SHA};sf=tgz` is currently down and breaking downstream vpx builds.